### PR TITLE
Add animated scroll-to-top button

### DIFF
--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import { ChevronUp } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { cn } from '@/lib/utils';
+
+const ScrollToTopButton: React.FC = () => {
+  const [visible, setVisible] = useState(false);
+  const { t, direction } = useLanguage();
+
+  useEffect(() => {
+    const onScroll = () => {
+      setVisible(window.scrollY > 300);
+    };
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const handleClick = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <div
+      className={cn(
+        'fixed z-50 bottom-6 md:bottom-8',
+        direction === 'rtl' ? 'left-6 md:left-8' : 'right-6 md:right-8'
+      )}
+    >
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            size="icon"
+            variant="default"
+            aria-label={t('back_to_top')}
+            onClick={handleClick}
+            className={cn(
+              'group rounded-full bg-gradient-turquoise text-white shadow-medium hover:shadow-glow transition-transform',
+              'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:zoom-in-95',
+              visible ? 'opacity-100' : 'opacity-0 pointer-events-none'
+            )}
+          >
+            <ChevronUp className="size-6 transition-transform group-hover:-translate-y-1 group-hover:rotate-90 motion-safe:group-hover:animate-spin" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{t('back_to_top')}</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+};
+
+export default ScrollToTopButton;

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -80,9 +80,10 @@ const translations = {
     
     // About Stats
     'about.stats.projects': 'Projects Completed',
-    'about.stats.clients': 'Happy Clients', 
+    'about.stats.clients': 'Happy Clients',
     'about.stats.experience': 'Years Experience',
     'about.stats.support': 'Support',
+    'back_to_top': 'Back to Top',
   },
   ar: {
     // Navigation
@@ -154,6 +155,7 @@ const translations = {
     'about.stats.clients': 'عميل راضي',
     'about.stats.experience': 'سنوات خبرة',
     'about.stats.support': 'دعم',
+    'back_to_top': 'العودة للأعلى',
   }
 };
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -11,6 +11,7 @@ import { Blog } from '@/components/Blog';
 import { FAQ } from '@/components/FAQ';
 import { Contact } from '@/components/Contact';
 import { Footer } from '@/components/Footer';
+import ScrollToTopButton from '@/components/ScrollToTopButton';
 
 const Index = () => {
   return (
@@ -27,6 +28,7 @@ const Index = () => {
           <FAQ />
           <Contact />
           <Footer />
+          <ScrollToTopButton />
         </div>
       </LanguageProvider>
     </ThemeProvider>


### PR DESCRIPTION
## Summary
- add translations for `back_to_top`
- create new `ScrollToTopButton` component with tooltip and animations
- include the button on the main index page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687db00108748330856ad45965f17d0a