### PR TITLE
Enhance contact form with phone field and success feedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.4",
         "@tanstack/react-query": "^5.56.2",
+        "canvas-confetti": "^1.9.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
@@ -3471,6 +3472,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.4",
     "@tanstack/react-query": "^5.56.2",
+    "canvas-confetti": "^1.9.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,23 +1,31 @@
 import React, { useState } from 'react';
-import { Mail, Phone, MapPin, Send } from 'lucide-react';
+import { Mail, Phone, MapPin, Send, CheckCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { toast } from '@/components/ui/sonner';
+import confetti from 'canvas-confetti';
 
 export const Contact: React.FC = () => {
   const { t, direction } = useLanguage();
   const [formData, setFormData] = useState({
     name: '',
     email: '',
+    phone: '',
     company: '',
     message: ''
   });
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    // Handle form submission
+    // Handle form submission (e.g., send data to API)
     console.log('Form submitted:', formData);
+    toast.success(t('contact.success'), {
+      icon: <CheckCircle className="text-green-500" />,
+    });
+    confetti({ particleCount: 100, spread: 70, origin: { y: 0.6 } });
+    setFormData({ name: '', email: '', phone: '', company: '', message: '' });
   };
 
   const contactInfo = [
@@ -84,6 +92,16 @@ export const Contact: React.FC = () => {
                   placeholder={t('contact.form.company')}
                   value={formData.company}
                   onChange={(e) => setFormData({ ...formData, company: e.target.value })}
+                  className="h-12 text-base"
+                />
+              </div>
+
+              <div>
+                <Input
+                  type="tel"
+                  placeholder={t('contact.form.phone')}
+                  value={formData.phone}
+                  onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
                   className="h-12 text-base"
                 />
               </div>

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -59,12 +59,14 @@ const translations = {
     
     // Contact
     'contact.title': 'Get In Touch',
-    'contact.subtitle': 'Ready to start your AR journey? Let\'s discuss your project.',
+    'contact.subtitle': "We're here to answer your questions or discuss your next big project!",
     'contact.form.name': 'Full Name',
     'contact.form.email': 'Email Address',
     'contact.form.company': 'Company',
+    'contact.form.phone': 'Phone (optional)',
     'contact.form.message': 'Project Details',
     'contact.form.submit': 'Send Message',
+    'contact.success': 'Thank you! We will get back to you soon.',
     
     // Testimonials
     'testimonials.title': 'Client Success Stories',
@@ -137,12 +139,14 @@ const translations = {
     
     // Contact
     'contact.title': 'تواصل معنا',
-    'contact.subtitle': 'مستعد لبدء رحلة الواقع المعزز؟ دعنا نناقش مشروعك.',
+    'contact.subtitle': 'جاهزون للرد على استفساراتك أو مناقشة مشروعك القادم!',
     'contact.form.name': 'الاسم الكامل',
     'contact.form.email': 'البريد الإلكتروني',
     'contact.form.company': 'الشركة',
+    'contact.form.phone': 'رقم الهاتف (اختياري)',
     'contact.form.message': 'تفاصيل المشروع',
     'contact.form.submit': 'إرسال الرسالة',
+    'contact.success': 'شكرًا لتواصلك معنا! سنرد عليك قريبًا.',
     
     // Testimonials
     'testimonials.title': 'قصص نجاح العملاء',


### PR DESCRIPTION
## Summary
- add `canvas-confetti` dependency
- show toast & confetti on contact form submission
- add phone field to contact form
- update translations for contact section

## Testing
- `npm run lint` *(fails: Error while loading rule `@typescript-eslint/no-unused-expressions`)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687dc66f0f0c83308ff0725281a97884