### PR TITLE
Improve header design with calm buttons

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { LanguageSwitcher } from './LanguageSwitcher';
 import { ThemeSwitcher } from './ThemeSwitcher';
 import { useLanguage } from '@/contexts/LanguageContext';
-import { Logo } from '@/components/ui/Logo'; // Assuming Logo is in the same directory
+import { Logo } from '@/components/ui/Logo';
 
 export const Header: React.FC = () => {
   const { t, direction } = useLanguage();
@@ -20,82 +20,54 @@ export const Header: React.FC = () => {
   ];
 
   return (
-    <header
-      className={`
-        fixed top-0 w-full z-50 border-b border-white/10
-        bg-gradient-to-r
-        from-white/70 via-blue-100 to-yellow-50
-        dark:from-gray-900/90 dark:via-blue-900/80 dark:to-yellow-800/40
-        backdrop-blur-lg
-        transition-all duration-500
-        shadow-[0_4px_32px_0_rgba(0,0,0,0.10)]
-      `}
-      style={{
-        backgroundSize: "200% 200%",
-        animation: "gradient-x 8s ease-in-out infinite"
-      }}
-    >
-      <style>{`
-        @keyframes gradient-x {
-          0%, 100% { background-position: 0% 50%; }
-          50%      { background-position: 100% 50%; }
-        }
-      `}</style>
-      <div className="container mx-auto px-4 lg:px-8">
-        <div className="flex items-center justify-between h-16">
-          {/* Logo */}
-          <div className="flex items-center space-x-3 rtl:space-x-reverse">
-            <Logo /> 
-          </div>
-      
+    <header className="fixed top-0 inset-x-0 z-50 border-b bg-white/80 dark:bg-gray-900/80 backdrop-blur-md shadow-soft">
+      <div className="container mx-auto flex items-center justify-between h-16 px-4 lg:px-8">
+        <div className="flex flex-1 items-center">
+          <Logo />
+        </div>
 
-          {/* Desktop Navigation */}
-          <nav className="hidden md:flex items-center space-x-8 rtl:space-x-reverse">
+        <nav className="hidden md:flex flex-1 items-center justify-center space-x-6 rtl:space-x-reverse">
+          {navigationItems.map((item) => (
+            <a
+              key={item.key}
+              href={item.href}
+              className="font-medium text-gray-800 dark:text-gray-200 hover:text-turquoise dark:hover:text-yellow-300"
+            >
+              {t(item.key)}
+            </a>
+          ))}
+        </nav>
+
+        <div className="flex flex-1 items-center justify-end space-x-3 rtl:space-x-reverse">
+          <ThemeSwitcher />
+          <LanguageSwitcher />
+          <Button
+            variant="ghost"
+            size="sm"
+            className="md:hidden p-2"
+            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+          >
+            {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
+          </Button>
+        </div>
+      </div>
+
+      {isMobileMenuOpen && (
+        <div className="md:hidden border-t border-white/10 bg-white/90 dark:bg-gray-900/95 backdrop-blur-md">
+          <nav className="py-4 space-y-2">
             {navigationItems.map((item) => (
               <a
                 key={item.key}
                 href={item.href}
-                className="text-gray-800 dark:text-gray-200 hover:text-turquoise dark:hover:text-yellow-300 transition-colors font-medium"
+                className="block rounded-md px-4 py-2 text-gray-800 hover:bg-turquoise/10 hover:text-turquoise dark:text-gray-100 dark:hover:bg-yellow-900/10 dark:hover:text-yellow-300"
+                onClick={() => setIsMobileMenuOpen(false)}
               >
                 {t(item.key)}
               </a>
             ))}
           </nav>
-
-          {/* Right Side */}
-          <div className="flex items-center space-x-4 rtl:space-x-reverse">
-            <ThemeSwitcher />
-            <LanguageSwitcher />
-            {/* Mobile Menu Button */}
-            <Button
-              variant="ghost"
-              size="sm"
-              className="md:hidden"
-              onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-            >
-              {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
-            </Button>
-          </div>
         </div>
-
-        {/* Mobile Navigation */}
-        {isMobileMenuOpen && (
-          <div className="md:hidden border-t border-white/10 bg-white/90 dark:bg-gray-900/95 backdrop-blur-lg">
-            <nav className="py-4 space-y-2">
-              {navigationItems.map((item) => (
-                <a
-                  key={item.key}
-                  href={item.href}
-                  className="block px-4 py-2 text-gray-800 dark:text-gray-100 hover:text-turquoise dark:hover:text-yellow-300 hover:bg-turquoise/10 dark:hover:bg-yellow-900/10 transition-colors rounded-md"
-                  onClick={() => setIsMobileMenuOpen(false)}
-                >
-                  {t(item.key)}
-                </a>
-              ))}
-            </nav>
-          </div>
-        )}
-      </div>
+      )}
     </header>
   );
 };

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -12,7 +12,7 @@ export const LanguageSwitcher: React.FC = () => {
         variant="ghost"
         size="sm"
         onClick={() => setLanguage(language === 'en' ? 'ar' : 'en')}
-        className="flex items-center gap-2 hover-lift text-foreground hover:text-turquoise transition-smooth"
+        className="flex items-center gap-2 text-foreground hover:text-turquoise"
       >
         <Languages size={18} />
         <span className="font-medium">

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -11,25 +11,10 @@ export const ThemeSwitcher: React.FC = () => {
       variant="ghost"
       size="sm"
       onClick={toggleTheme}
-      className="relative w-10 h-10 rounded-full hover-lift transition-smooth hover:bg-primary/10"
+      className="w-10 h-10 rounded-full hover:bg-primary/10"
       aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
     >
-      <div className="relative w-5 h-5">
-        <Sun 
-          className={`absolute inset-0 transition-all duration-300 ${
-            theme === 'light' 
-              ? 'rotate-0 scale-100 opacity-100' 
-              : '-rotate-90 scale-0 opacity-0'
-          }`}
-        />
-        <Moon 
-          className={`absolute inset-0 transition-all duration-300 ${
-            theme === 'dark' 
-              ? 'rotate-0 scale-100 opacity-100' 
-              : 'rotate-90 scale-0 opacity-0'
-          }`}
-        />
-      </div>
+      {theme === 'light' ? <Sun size={18} /> : <Moon size={18} />}
     </Button>
   );
 };

--- a/src/components/ui/Logo.tsx
+++ b/src/components/ui/Logo.tsx
@@ -9,18 +9,12 @@ export const Logo = () => {
   const logoVariant = theme === 'dark' ? 'logo-dark.png' : 'logo-day.png';
 
   return (
-    <Link to="/" className="group flex items-center space-x-3 rtl:space-x-reverse">
-      <span className="
-        flex items-center justify-center
-        rounded-2xl transition-all duration-300 ease-in-out
-        group-hover:scale-105 group-hover:shadow-lg
-        bg-transparent
-      ">
+    <Link to="/" className="flex items-center">
+      <span className="flex items-center justify-center rounded-2xl">
         <img
           src={`/${logoVariant}`}
           alt="Ask-ar Logo"
-          className="w-21 h-12 object-contain select-none"
-          style={{ filter: "drop-shadow(0 4px 14px #06B6D499)" }}
+          className="w-24 h-12 object-contain select-none drop-shadow-md"
           draggable={false}
         />
       </span>


### PR DESCRIPTION
## Summary
- simplify header design and remove extraneous animations
- tone down ThemeSwitcher and LanguageSwitcher buttons
- streamline Logo component

## Testing
- `npm run lint` *(fails: cannot read property 'allowShortCircuit')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ea36375c48330b96cbf9c28214dbe