### PR TITLE
Adjust hero slider positioning

### DIFF
--- a/src/components/HeroSlider.tsx
+++ b/src/components/HeroSlider.tsx
@@ -33,7 +33,7 @@ const HeroSlider: React.FC = () => {
   return (
     <section
       id="hero"
-      className="relative mt-16 h-[calc(100vh-4rem)] w-full overflow-hidden"
+      className="relative mt-20 h-[calc(100vh-5rem)] w-full overflow-hidden"
       onMouseEnter={pause}
       onMouseLeave={play}
       onTouchStart={pause}


### PR DESCRIPTION
## Summary
- offset hero slider further down to avoid navigation overlay

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687fb0d6a03c8330827855d3860ee762