### PR TITLE
Fix hero slider overlap

### DIFF
--- a/src/components/HeroSlider.tsx
+++ b/src/components/HeroSlider.tsx
@@ -36,7 +36,7 @@ const HeroSlider: React.FC = () => {
   className="
     relative
     w-full
-    pt-16
+    mt-16
     min-h-[calc(100vh-64px)]
     max-h-[1200px]
     overflow-hidden

--- a/src/index.css
+++ b/src/index.css
@@ -375,7 +375,7 @@
   }
 }
 #hero {
-  scroll-margin-top: 64px;
+  scroll-margin-top: 0;
 }
 
 /* Print Styles */


### PR DESCRIPTION
## Summary
- offset hero slider below the fixed navbar
- adjust hero scroll margin

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687fe05d2228833087532def70afc1d8