### PR TITLE
Implement autoplay hero slider

### DIFF
--- a/src/components/HeroSlider.tsx
+++ b/src/components/HeroSlider.tsx
@@ -1,33 +1,51 @@
-import React, { useEffect, useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
-import { useLanguage } from '@/contexts/LanguageContext';
+import React, { useEffect, useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { useLanguage } from '@/contexts/LanguageContext'
 
-const NAVBAR_HEIGHT = 64;
-const TRANSITION_DURATION = 2;
-const DISPLAY_DURATION = 7000;
-const MOBILE_MIN_HEIGHT = 500;
+const NAVBAR_HEIGHT = 64
+const TRANSITION_DURATION = 2
+const DISPLAY_DURATION = 7000
+const MOBILE_MIN_HEIGHT = 500
 
 const images = [
   '/hero1.png',
   '/hero2.png',
   '/hero3.png',
   '/hero4.png',
-  '/hero5.png'
-];
+  '/hero5.png',
+]
+
+interface Direction {
+  x: string | number
+  y: string | number
+}
+
+const slideDirections: Direction[] = [
+  { x: '-100%', y: 0 },
+  { x: '100%', y: 0 },
+  { x: 0, y: '-100%' },
+  { x: 0, y: '100%' },
+  { x: '-100%', y: '-100%' },
+  { x: '100%', y: '-100%' },
+  { x: '-100%', y: '100%' },
+  { x: '100%', y: '100%' },
+]
+
+const getRandomDirection = () =>
+  slideDirections[Math.floor(Math.random() * slideDirections.length)]
 
 const HeroSlider: React.FC = () => {
-  const { t } = useLanguage();
-  const [index, setIndex] = useState(0);
-  const [paused, setPaused] = useState(false);
+  const { t } = useLanguage()
+  const [index, setIndex] = useState(0)
+  const [direction, setDirection] = useState<Direction>(getRandomDirection())
 
   useEffect(() => {
-    if (paused) return;
-    const timer = setTimeout(() => setIndex(i => (i + 1) % images.length), DISPLAY_DURATION);
-    return () => clearTimeout(timer);
-  }, [index, paused]);
-
-  const pause = () => setPaused(true);
-  const play = () => setPaused(false);
+    const timer = setTimeout(() => {
+      setIndex((i) => (i + 1) % images.length)
+      setDirection(getRandomDirection())
+    }, DISPLAY_DURATION)
+    return () => clearTimeout(timer)
+  }, [index])
 
   return (
     <section
@@ -36,12 +54,8 @@ const HeroSlider: React.FC = () => {
       style={{
         paddingTop: `${NAVBAR_HEIGHT}px`,
         minHeight: `calc(100vh - ${NAVBAR_HEIGHT}px)`,
-        maxHeight: '1024px'
+        maxHeight: '1024px',
       }}
-      onMouseEnter={pause}
-      onMouseLeave={play}
-      onTouchStart={pause}
-      onTouchEnd={play}
     >
       <div className="absolute inset-0 w-full h-full">
         <AnimatePresence mode="wait">
@@ -50,27 +64,16 @@ const HeroSlider: React.FC = () => {
             src={images[index]}
             alt={`Hero slide ${index + 1}`}
             className="absolute inset-0 w-full h-full object-cover"
-            initial={{ opacity: 0, x: 100 }}
-            animate={{ opacity: 1, x: 0 }}
-            exit={{ opacity: 0, x: -100 }}
+            initial={{ opacity: 0, ...direction }}
+            animate={{ opacity: 1, x: 0, y: 0 }}
+            exit={{ opacity: 0, ...direction }}
             transition={{ duration: TRANSITION_DURATION, ease: 'easeInOut' }}
             style={{ minHeight: `${MOBILE_MIN_HEIGHT}px` }}
           />
         </AnimatePresence>
       </div>
 
-      <div className="absolute inset-0 bg-gradient-to-b from-black/40 via-black/20 to-black/60" />
-
-      <div className="absolute bottom-6 left-1/2 transform -translate-x-1/2 flex space-x-2 z-20">
-        {images.map((_, i) => (
-          <button
-            key={i}
-            onClick={() => setIndex(i)}
-            className={`w-3 h-3 rounded-full transition-all duration-300 ${i === index ? 'bg-white scale-110 shadow-lg' : 'bg-white/50 hover:bg-white/70'}`}
-            aria-label={`Go to slide ${i + 1}`}
-          />
-        ))}
-      </div>
+      <div className="absolute inset-0 bg-gradient-to-b from-black/40 via-black/20 to-black/60 pointer-events-none" />
 
       <div className="relative z-10 flex h-full w-full items-center justify-center px-4 sm:px-6 lg:px-8">
         <div className="max-w-4xl mx-auto text-center text-white">
@@ -94,19 +97,6 @@ const HeroSlider: React.FC = () => {
         </div>
       </div>
 
-      <button
-        onClick={() => setIndex(i => (i - 1 + images.length) % images.length)}
-        className="hidden md:flex absolute left-4 top-1/2 transform -translate-y-1/2 bg-white/20 hover:bg-white/30 backdrop-blur-sm text-white p-3 rounded-full transition z-20"
-      >
-        ◀️
-      </button>
-
-      <button
-        onClick={() => setIndex(i => (i + 1) % images.length)}
-        className="hidden md:flex absolute right-4 top-1/2 transform -translate-y-1/2 bg-white/20 hover:bg-white/30 backdrop-blur-sm text-white p-3 rounded-full transition z-20"
-      >
-        ▶️
-      </button>
     </section>
   );
 };


### PR DESCRIPTION
## Summary
- enable automatic playback with dynamic transition directions
- remove manual controls from the hero slider
- randomize slide entry directions for variety

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6880033ff1488330aaff878937360946