### PR TITLE
Add Egyptian Arabic and RTL improvements

### DIFF
--- a/src/components/HeroSlider.tsx
+++ b/src/components/HeroSlider.tsx
@@ -13,6 +13,7 @@ const slides = [
     text: {
       en: 'Technology that leads. Future that inspires.',
       ar: 'تقنية تقود، ومستقبل يلهم.',
+      eg: 'تكنولوجيا بتفتح الطريق وبتلهم بكرة.',
     },
   },
   {
@@ -20,6 +21,7 @@ const slides = [
     text: {
       en: 'Where data flows, possibilities grow.',
       ar: 'حيث تتدفق البيانات، تنمو الفرص.',
+      eg: 'لما البيانات تتحرك، الفرص تكتر.',
     },
   },
   {
@@ -27,6 +29,7 @@ const slides = [
     text: {
       en: 'Your smart partner in digital transformation.',
       ar: 'شريكك الذكي في التحول الرقمي.',
+      eg: 'شريكك الشاطر في التحول الرقمي.',
     },
   },
   {
@@ -34,6 +37,7 @@ const slides = [
     text: {
       en: 'Securing progress with innovation and trust.',
       ar: 'نؤمن التقدم بالابتكار والثقة.',
+      eg: 'بنوفرلك تطور مضمون بالابتكار والثقة.',
     },
   },
   {
@@ -41,6 +45,7 @@ const slides = [
     text: {
       en: 'Experience seamless connectivity, everywhere.',
       ar: 'اختبر الاتصال الذكي… في كل مكان.',
+      eg: 'استمتع باتصال من غير حدود، في أي مكان.',
     },
   },
 ]
@@ -162,7 +167,7 @@ const HeroSlider: React.FC = () => {
   const { language } = useLanguage()
   const [index, setIndex] = useState(0)
 
-  const isRTL = language === 'ar'
+  const isRTL = language !== 'en'
   const side = index % 2 === 0 ? 'left' : 'right'
   const actualSide = isRTL ? (side === 'left' ? 'right' : 'left') : side
   const sign = actualSide === 'left' ? -1 : 1

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from "react";
 import { Menu, X, Sun, Moon, Globe } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useLanguage } from "@/contexts/LanguageContext";
+import type { Language } from "@/contexts/LanguageContext";
 import { useTheme } from "@/contexts/ThemeContext";
 import { Logo } from "@/components/ui/logo";
 import { useScrollSpy } from "@/hooks/useScrollSpy";
@@ -74,9 +75,11 @@ const Navigation = () => {
     }
   };
 
+  const isRTL = language !== "en";
+
   return (
     <nav
-      dir={language === "ar" ? "rtl" : "ltr"}
+      dir={isRTL ? "rtl" : "ltr"}
       className={`
         fixed top-0 w-full z-50 
         transition-all duration-300
@@ -130,11 +133,15 @@ const Navigation = () => {
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => setLanguage(language === "en" ? "ar" : "en")}
+              onClick={() => {
+                const order: Language[] = ["en", "ar", "eg"];
+                const next = order[(order.indexOf(language) + 1) % order.length];
+                setLanguage(next);
+              }}
               className="rounded-full text-xs lg:text-sm"
             >
               <Globe className="h-3 w-3 lg:h-4 lg:w-4 mr-1 lg:mr-2" />
-              {language === "en" ? "العربية" : "English"}
+              {language === "en" ? "العربية" : language === "ar" ? "مصري" : "English"}
             </Button>
           </div>
 

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -37,8 +37,8 @@ const ScrollToTop = () => {
   return (
     <button
       onClick={scrollToTop}
-      aria-label={language === 'ar' ? 'العودة للأعلى' : 'Back to top'}
-      className={`fixed bottom-6 ${language === 'ar' ? 'left-6' : 'right-6'} z-40 p-3 rounded-full bg-primary text-white shadow-premium transition-opacity duration-300 hover:bg-primary-hover focus:outline-none ${
+      aria-label={language !== 'en' ? 'العودة للأعلى' : 'Back to top'}
+      className={`fixed bottom-6 ${language !== 'en' ? 'left-6' : 'right-6'} z-40 p-3 rounded-full bg-primary text-white shadow-premium transition-opacity duration-300 hover:bg-primary-hover focus:outline-none ${
         visible ? 'opacity-100' : 'opacity-0 pointer-events-none'
       }`}
     >

--- a/src/components/ui/logo.tsx
+++ b/src/components/ui/logo.tsx
@@ -17,7 +17,7 @@ export const Logo = ({ className = "", clickable = false }) => {
     setLogoSrc(getLogoSrc());
   }, [theme, language]);
 
-  const altTitle = language === "ar" ? "شعار الشركة" : "Company Logo";
+  const altTitle = language === "en" ? "Company Logo" : "شعار الشركة";
 
   return (
     <span

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,7 +1,7 @@
 
 import React, { createContext, useContext, useState, ReactNode } from 'react';
 
-type Language = 'en' | 'ar';
+export type Language = 'en' | 'ar' | 'eg';
 
 interface LanguageContextType {
   language: Language;
@@ -105,7 +105,56 @@ const translations = {
     // Footer
     allRightsReserved: 'جميع الحقوق محفوظة.',
     followUs: 'تابعنا',
-  }
+  },
+  eg: {
+    // Navigation
+    home: 'الرئيسية',
+    services: 'الخدمات',
+    about: 'عننا',
+    contact: 'اتصل بينا',
+
+    // Hero Section
+    heroTitle: 'حلول برمجية مبتكرة',
+    heroSubtitle: 'بنطوّرلك شغلك بأحدث التقنيات والبرمجيات المخصصة',
+    getStarted: 'يلا نبدأ',
+    learnMore: 'اعرف أكتر',
+
+    // Services
+    servicesTitle: 'خدماتنا',
+    servicesSubtitle: 'حلول برمجية متكاملة تناسب احتياجاتك',
+    webDev: 'تطوير مواقع',
+    webDevDesc: 'مواقع وتطبيقات ويب عصرية ومتجاوبة',
+    mobileDev: 'تطبيقات موبايل',
+    mobileDevDesc: 'تطبيقات أصلية ومشتركة لـ iOS وAndroid',
+    cloudSolutions: 'حلول سحابية',
+    cloudSolutionsDesc: 'بنية تحتية سحابية مرنة وآمنة',
+    consulting: 'استشارات تقنية',
+    consultingDesc: 'نصائح تقنية عملية لتحسين شغلك',
+
+    // About
+    aboutTitle: 'إحنا أسكار للحلول البرمجية',
+    aboutDesc:
+      'فريق محترف بيحوّل أفكارك لمنتجات رقمية قوية تساعد على نمو عملك.',
+    yearsExperience: 'سنين خبرة',
+    projectsCompleted: 'مشاريع مكتملة',
+    happyClients: 'عملاء مبسوطين',
+    teamMembers: 'أفراد الفريق',
+
+    // Contact
+    contactTitle: 'كلمنا',
+    contactSubtitle: 'كلّمنا في أي وقت، فريقنا معاك على طول!',
+    name: 'الاسم',
+    email: 'البريد الإلكتروني',
+    message: 'رسالتك',
+    sendMessage: 'ابعت الرسالة',
+    phone: 'التليفون',
+    address: 'العنوان',
+    officeHours: 'ساعات العمل',
+
+    // Footer
+    allRightsReserved: 'كل الحقوق محفوظة.',
+    followUs: 'تابعنا',
+  },
 };
 
 const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
@@ -122,9 +171,11 @@ export const LanguageProvider = ({ children }: { children: ReactNode }) => {
     return translations[language][key as keyof typeof translations['en']] || key;
   };
 
+  const isRTL = language !== 'en';
+
   return (
     <LanguageContext.Provider value={{ language, setLanguage, t }}>
-      <div className={language === 'ar' ? 'rtl' : 'ltr'} dir={language === 'ar' ? 'rtl' : 'ltr'}>
+      <div className={isRTL ? 'rtl' : 'ltr'} dir={isRTL ? 'rtl' : 'ltr'}>
         {children}
       </div>
     </LanguageContext.Provider>


### PR DESCRIPTION
## Summary
- add Egyptian Arabic translations and export `Language` type
- cycle between English, Arabic, and Egyptian Arabic in navbar
- handle RTL layout for Arabic variants
- localize hero slider captions
- update scroll-to-top button and logo alt text for new language logic

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68803506a4108330a88a79ea28b77676