### PR TITLE
Implement projects section with animations

### DIFF
--- a/src/components/HeroSlider.tsx
+++ b/src/components/HeroSlider.tsx
@@ -1,54 +1,13 @@
-import React, { useEffect, useState } from 'react'
- 
-import { motion, AnimatePresence, easeInOut } from 'framer-motion'
-import { useLanguage } from '@/contexts/LanguageContext'
-import clsx from 'clsx'
- 
+import React, { useEffect, useState } from 'react';
+import { motion, AnimatePresence, easeInOut } from 'framer-motion';
+import { useLanguage } from '@/contexts/LanguageContext';
+import clsx from 'clsx';
 
-const NAVBAR_HEIGHT = 64
-const DISPLAY_DURATION = 3000 // ms
-const MOBILE_MIN_HEIGHT = 500
+const NAVBAR_HEIGHT = 64;
+const DISPLAY_DURATION = 3000; // ms
+const MOBILE_MIN_HEIGHT = 500;
 
 const slides = [
- 
-  { image: '/hero1.png' },
-  { image: '/hero2.png' },
-  { image: '/hero3.png' },
-  { image: '/hero4.png' },
-  { image: '/hero5.png' },
-]
-
-const slideVariants = [
-  // 1. slow zoom-in from center
-  {
-    initial: { opacity: 0, scale: 1 },
-    animate: { opacity: 1, scale: 1.1, transition: { duration: DISPLAY_DURATION / 1000 } },
-    exit: { opacity: 0, scale: 1.2, transition: { duration: 0.8 } },
-  },
-  // 2. fade-in with gentle zoom
-  {
-    initial: { opacity: 0, scale: 1 },
-    animate: { opacity: 1, scale: 1.05, transition: { duration: DISPLAY_DURATION / 1000 } },
-    exit: { opacity: 0, scale: 1.1, transition: { duration: 0.8 } },
-  },
-  // 3. slide in from right with light zoom
-  {
-    initial: { opacity: 0, x: 80, scale: 1 },
-    animate: { opacity: 1, x: 0, scale: 1.05, transition: { duration: DISPLAY_DURATION / 1000 } },
-    exit: { opacity: 0, x: -80, scale: 1.05, transition: { duration: 0.8 } },
-  },
-  // 4. subtle scale from center
-  {
-    initial: { opacity: 0, scale: 0.9 },
-    animate: { opacity: 1, scale: 1, transition: { duration: DISPLAY_DURATION / 1000 } },
-    exit: { opacity: 0, scale: 1.1, transition: { duration: 0.8 } },
-  },
-  // 5. rise from bottom with zoom out
-  {
-    initial: { opacity: 0, y: 60, scale: 1.05 },
-    animate: { opacity: 1, y: 0, scale: 1, transition: { duration: DISPLAY_DURATION / 1000 } },
-    exit: { opacity: 0, y: -60, scale: 0.95, transition: { duration: 0.8 } },
- 
   {
     image: '/hero1.png',
     text: {
@@ -89,7 +48,7 @@ const slideVariants = [
       eg: 'استمتع باتصال من غير حدود، في أي مكان.',
     },
   },
-]
+];
 
 const slideVariants = [
   // 1. Slow Zoom In (center)
@@ -201,30 +160,26 @@ const slideVariants = [
       y: -40,
       transition: { duration: 1.2, ease: easeInOut },
     },
- 
   },
-]
+];
 
 const HeroSlider: React.FC = () => {
- 
-  const { language } = useLanguage()
- 
-  const [index, setIndex] = useState(0)
+  const { language } = useLanguage();
+  const [index, setIndex] = useState(0);
 
-  const isRTL = language !== 'en'
-  const side = index % 2 === 0 ? 'left' : 'right'
-  const actualSide = isRTL ? (side === 'left' ? 'right' : 'left') : side
-  const sign = actualSide === 'left' ? -1 : 1
-  const fromX = 60 * sign
-  const exitX = -60 * sign
+  const isRTL = language !== 'en';
+  const side = index % 2 === 0 ? 'left' : 'right';
+  const actualSide = isRTL ? (side === 'left' ? 'right' : 'left') : side;
+  const sign = actualSide === 'left' ? -1 : 1;
+  const fromX = 60 * sign;
+  const exitX = -60 * sign;
 
-  useEffect(() => { 
+  useEffect(() => {
     const timer = setInterval(() => {
- 
-      setIndex(i => (i + 1) % slides.length)
-    }, DISPLAY_DURATION)
-    return () => clearInterval(timer)
-  }, [])
+      setIndex((i) => (i + 1) % slides.length);
+    }, DISPLAY_DURATION);
+    return () => clearInterval(timer);
+  }, []);
 
   return (
     <section
@@ -232,13 +187,11 @@ const HeroSlider: React.FC = () => {
       className="relative w-full overflow-hidden flex items-center justify-center"
       style={{
         paddingTop: `${NAVBAR_HEIGHT}px`,
- 
         minHeight: `calc(145vh - ${NAVBAR_HEIGHT}px)`,
- 
         maxHeight: '1024px',
       }}
     >
-   <div className="absolute inset-0 w-full h-full">
+      <div className="absolute inset-0 w-full h-full">
         <AnimatePresence mode="wait">
           <motion.img
             key={index}
@@ -249,17 +202,13 @@ const HeroSlider: React.FC = () => {
             initial="initial"
             animate="show"
             exit="exit"
-            style={{
-              minHeight: `${MOBILE_MIN_HEIGHT}px`,
-              zIndex: 10,
-            }}
+            style={{ minHeight: `${MOBILE_MIN_HEIGHT}px`, zIndex: 10 }}
           />
         </AnimatePresence>
       </div>
 
       <div className="absolute inset-0 bg-gradient-to-b from-black/40 via-black/20 to-black/60 pointer-events-none" />
 
- 
       <div className="relative z-20 flex h-full w-full items-center px-4 sm:px-6 lg:px-8">
         <AnimatePresence mode="wait">
           <motion.div
@@ -280,9 +229,8 @@ const HeroSlider: React.FC = () => {
           </motion.div>
         </AnimatePresence>
       </div>
- 
     </section>
-  )
-}
+  );
+};
 
-export default HeroSlider
+export default HeroSlider;

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { motion } from 'framer-motion';
+
+const cardVariants = {
+  hidden: { opacity: 0, y: 40 },
+  visible: (i: number) => ({
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.6, delay: i * 0.2 },
+  }),
+};
+
+const Projects: React.FC = () => {
+  const { t } = useLanguage();
+
+  const projects = [
+    {
+      image: '/hero3.png',
+      title: t('project1Title'),
+      description: t('project1Desc'),
+    },
+    {
+      image: '/hero4.png',
+      title: t('project2Title'),
+      description: t('project2Desc'),
+    },
+    {
+      image: '/hero5.png',
+      title: t('project3Title'),
+      description: t('project3Desc'),
+    },
+  ];
+
+  return (
+    <section id="projects" className="py-20 bg-white dark:bg-gray-800">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16">
+          <h2 className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-4">
+            {t('projectsTitle')}
+          </h2>
+          <p className="text-xl text-gray-600 dark:text-gray-400 max-w-3xl mx-auto">
+            {t('projectsSubtitle')}
+          </p>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          {projects.map((project, index) => (
+            <motion.div
+              key={index}
+              custom={index}
+              variants={cardVariants}
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true, amount: 0.3 }}
+            >
+              <Card className="overflow-hidden group shadow-lg hover:shadow-xl transition-shadow duration-300">
+                <div className="relative h-48 overflow-hidden">
+                  <img
+                    src={project.image}
+                    alt={project.title}
+                    className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                    loading="lazy"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-b from-black/40 via-black/20 to-black/60" />
+                </div>
+                <CardHeader>
+                  <CardTitle className="text-2xl font-semibold text-gray-900 dark:text-white">
+                    {project.title}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <CardDescription className="text-gray-600 dark:text-gray-300">
+                    {project.description}
+                  </CardDescription>
+                </CardContent>
+              </Card>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Projects;

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Code, Smartphone, Cloud, Users } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { motion } from 'framer-motion';
 
 const Services = () => {
   const { t } = useLanguage();
@@ -50,24 +51,33 @@ const Services = () => {
           {services.map((service, index) => {
             const Icon = service.icon;
             return (
-              <Card key={index} className="relative overflow-hidden hover:shadow-xl transition-all duration-300 transform hover:-translate-y-2 group">
-                <CardHeader className="text-center pb-4">
-                  <div className={`w-16 h-16 ${service.color} rounded-full flex items-center justify-center mx-auto mb-4 group-hover:scale-110 transition-transform duration-300`}>
-                    <Icon className="h-8 w-8 text-white" />
-                  </div>
-                  <CardTitle className="text-xl font-semibold text-gray-900 dark:text-white">
-                    {service.title}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription className="text-gray-600 dark:text-gray-400 text-center leading-relaxed">
-                    {service.description}
-                  </CardDescription>
-                </CardContent>
-                
-                {/* Animated border */}
-                <div className="absolute inset-0 bg-gradient-to-r from-blue-500 to-purple-500 opacity-0 group-hover:opacity-10 transition-opacity duration-300 rounded-lg"></div>
-              </Card>
+              <motion.div
+                key={index}
+                custom={index}
+                initial={{ opacity: 0, y: 40 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, amount: 0.3 }}
+                transition={{ duration: 0.6, delay: index * 0.2 }}
+              >
+                <Card className="relative overflow-hidden hover:shadow-xl transition-all duration-300 transform hover:-translate-y-2 group">
+                  <CardHeader className="text-center pb-4">
+                    <div className={`w-16 h-16 ${service.color} rounded-full flex items-center justify-center mx-auto mb-4 group-hover:scale-110 transition-transform duration-300`}>
+                      <Icon className="h-8 w-8 text-white" />
+                    </div>
+                    <CardTitle className="text-xl font-semibold text-gray-900 dark:text-white">
+                      {service.title}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <CardDescription className="text-gray-600 dark:text-gray-400 text-center leading-relaxed">
+                      {service.description}
+                    </CardDescription>
+                  </CardContent>
+
+                  {/* Animated border */}
+                  <div className="absolute inset-0 bg-gradient-to-r from-blue-500 to-purple-500 opacity-0 group-hover:opacity-10 transition-opacity duration-300 rounded-lg"></div>
+                </Card>
+              </motion.div>
             );
           })}
         </div>

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -34,6 +34,16 @@ const translations = {
     cloudSolutionsDesc: 'Scalable cloud infrastructure and deployment solutions',
     consulting: 'IT Consulting',
     consultingDesc: 'Strategic technology consulting to optimize your business processes',
+
+    // Projects
+    projectsTitle: 'Our Projects',
+    projectsSubtitle: 'Recent case studies from our clients',
+    project1Title: 'Smart School Platform',
+    project1Desc: 'Unified education management with mobile apps.',
+    project2Title: 'Clinic Management System',
+    project2Desc: 'Secure patient records and online appointments.',
+    project3Title: 'AI Sales Insights',
+    project3Desc: 'Data-driven recommendations boosting revenue.',
     
     // About
     aboutTitle: 'About Askar Software Solutions',
@@ -82,6 +92,16 @@ const translations = {
     cloudSolutionsDesc: 'بنية تحتية سحابية قابلة للتوسع وحلول نشر متقدمة',
     consulting: 'استشارات تقنية',
     consultingDesc: 'استشارات تقنية استراتيجية لتحسين العمليات التجارية',
+
+    // Projects
+    projectsTitle: 'مشاريعنا',
+    projectsSubtitle: 'نستعرض أحدث قصص النجاح لعملائنا',
+    project1Title: 'منصة المدرسة الذكية',
+    project1Desc: 'إدارة تعليمية موحدة مع تطبيقات للجوال.',
+    project2Title: 'نظام إدارة العيادات',
+    project2Desc: 'سجلات مرضى آمنة وحجوزات عبر الإنترنت.',
+    project3Title: 'تحليلات المبيعات بالذكاء الاصطناعي',
+    project3Desc: 'توصيات مبنية على البيانات لزيادة الإيرادات.',
     
     // About
     aboutTitle: 'حول أسكر للحلول البرمجية',
@@ -130,6 +150,16 @@ const translations = {
     cloudSolutionsDesc: 'بنية تحتية سحابية مرنة وآمنة',
     consulting: 'استشارات تقنية',
     consultingDesc: 'نصائح تقنية عملية لتحسين شغلك',
+
+    // Projects
+    projectsTitle: 'مشاريعنا',
+    projectsSubtitle: 'أحدث قصص النجاح مع عملائنا',
+    project1Title: 'منصة المدرسة الذكية',
+    project1Desc: 'إدارة تعليمية متكاملة بتطبيقات موبايل.',
+    project2Title: 'نظام عيادات متكامل',
+    project2Desc: 'حجوزات ومتابعة مرضى بشكل آمن.',
+    project3Title: 'تحليلات مبيعات ذكية',
+    project3Desc: 'توصيات بتعتمد على البيانات لزيادة الربح.',
 
     // About
     aboutTitle: 'إحنا أسكار للحلول البرمجية',

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Navigation from '@/components/Navigation';
 import HeroSlider from '@/components/HeroSlider';
 import Services from '@/components/Services';
+import Projects from '@/components/Projects';
 import About from '@/components/About';
 import Contact from '@/components/Contact';
 import Footer from '@/components/Footer';
@@ -14,6 +15,7 @@ const Index = () => {
       <Navigation />
       <HeroSlider />
       <Services />
+      <Projects />
       <About />
       <Contact />
       <Footer />


### PR DESCRIPTION
## Summary
- add new Projects section
- animate Services cards on scroll
- update hero slider structure
- extend translations with project labels
- include Projects in homepage

## Testing
- `npm run lint`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_688071b0277c8330a55c0b9f85f8b1b7