### PR TITLE
Update navigation link color

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -134,11 +134,13 @@ const Navigation: React.FC = () => {
                   whileTap={{ scale: 0.95 }}
                   className={cn(
                     "relative font-semibold text-lg tracking-wide transition-all duration-300",
-                    isActive ? "text-white" : "text-gray-300 hover:text-white"
+                    isActive
+                      ? "text-[#53cfeb]"
+                      : "text-white hover:text-[#53cfeb]"
                   )}
                   style={{
                     textShadow: isActive
-                      ? "0 0 12px rgba(255,255,255,0.8), 0 0 24px rgba(255,255,255,0.6)"
+                      ? "0 0 12px rgba(83,207,235,0.8), 0 0 24px rgba(83,207,235,0.6)"
                       : "0 0 6px rgba(255,255,255,0.2)",
                   }}
                 >
@@ -204,7 +206,7 @@ const Navigation: React.FC = () => {
                       y: 0,
                       transition: { delay: index * 0.1, duration: 0.3, ease: "easeOut" },
                     }}
-                    className="text-2xl font-semibold text-white"
+                    className="text-2xl font-semibold text-white hover:text-[#53cfeb]"
                     style={{
                       textShadow: "0 0 8px rgba(255,255,255,0.8), 0 0 20px rgba(255,255,255,0.6)",
                     }}


### PR DESCRIPTION
## Summary
- highlight active navigation links in cyan
- add cyan hover state for links in mobile menu

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6883d2f81e88833099efc2c083a700e6