### PR TITLE
Add routed pages for about, services and portfolio

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,9 @@ import { LanguageProvider } from "@/contexts/LanguageContext";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import Index from "./pages/Index";
 import SiteIndex from "./pages/SiteIndex";
+import AboutPage from "./pages/AboutPage";
+import ServicesPage from "./pages/ServicesPage";
+import PortfolioPage from "./pages/PortfolioPage";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -23,6 +26,9 @@ const App = () => (
             <Routes>
               <Route path="/" element={<SiteIndex />} />
               <Route path="/demo" element={<Index />} />
+              <Route path="/services" element={<ServicesPage />} />
+              <Route path="/about" element={<AboutPage />} />
+              <Route path="/portfolio" element={<PortfolioPage />} />
               <Route path="*" element={<NotFound />} />
             </Routes>
           </BrowserRouter>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -8,6 +8,7 @@ import { Logo } from "@/components/ui/logo";
 import { useScrollSpy } from "@/hooks/useScrollSpy";
 import { motion, AnimatePresence, easeOut, easeInOut } from "framer-motion";
 import { cn } from "@/lib/utils";
+import { useLocation, useNavigate } from "react-router-dom";
 
 const NAVBAR_HEIGHT = 64;
 
@@ -37,6 +38,8 @@ const Navigation: React.FC = () => {
   const { language, setLanguage, t, isRTL } = useLanguage();
   const { theme, toggleTheme } = useTheme();
   const [scrolled, setScrolled] = useState(false);
+  const location = useLocation();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 10);
@@ -47,11 +50,11 @@ const Navigation: React.FC = () => {
 
   const navItems = useMemo(
     () => [
-      { key: "home" as const, href: "#hero" },
-      { key: "services" as const, href: "#services" },
-      { key: "about" as const, href: "#about" },
-      { key: "projects" as const, href: "#projects" },
-      { key: "contact" as const, href: "#contact" },
+      { key: "home" as const, href: "#hero", path: "/" },
+      { key: "services" as const, href: "#services", path: "/services" },
+      { key: "about" as const, href: "#about", path: "/about" },
+      { key: "projects" as const, href: "#projects", path: "/portfolio" },
+      { key: "contact" as const, href: "#contact", path: "/#contact" },
     ],
     []
   );
@@ -70,6 +73,19 @@ const Navigation: React.FC = () => {
       setIsOpen(false);
     }
   }, []);
+
+  const handleNavItemClick = useCallback(
+    (item: { href: string; path: string }) => {
+      const basePath = item.path.split("#")[0];
+      if (location.pathname === basePath) {
+        scrollToSection(item.href.slice(1));
+      } else {
+        navigate(item.path);
+        setIsOpen(false);
+      }
+    },
+    [location.pathname, navigate, scrollToSection]
+  );
 
   const handleLanguageChange = useCallback(() => {
     const order: Language[] = ["en", "ar", "eg"];
@@ -134,7 +150,7 @@ const Navigation: React.FC = () => {
               return (
                <motion.button
                   key={item.key}
-                  onClick={() => scrollToSection(item.href.slice(1))}
+                  onClick={() => handleNavItemClick(item)}
                   whileHover={{ scale: 1.08 }}
                   whileTap={{ scale: 0.95 }}
                   className={cn(
@@ -201,7 +217,7 @@ const Navigation: React.FC = () => {
                 {navItems.map((item, index) => (
                   <motion.button
                     key={item.key}
-                    onClick={() => scrollToSection(item.href.slice(1))}
+                    onClick={() => handleNavItemClick(item)}
                     initial={{ opacity: 0, y: 20 }}
                     animate={{
                       opacity: 1,

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Navigation from '@/components/Navigation';
+import About from '@/components/About';
+import CTA from '@/components/CTA';
+import Contact from '@/components/Contact';
+import Footer from '@/components/Footer';
+import ScrollToTop from '@/components/ScrollToTop';
+
+const AboutPage: React.FC = () => (
+  <div className="min-h-screen">
+    <Navigation />
+    <About />
+    <CTA />
+    <Contact />
+    <Footer />
+    <ScrollToTop />
+  </div>
+);
+
+export default AboutPage;

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Navigation from '@/components/Navigation';
+import Projects from '@/components/Projects';
+import CTA from '@/components/CTA';
+import Contact from '@/components/Contact';
+import Footer from '@/components/Footer';
+import ScrollToTop from '@/components/ScrollToTop';
+
+const PortfolioPage: React.FC = () => (
+  <div className="min-h-screen">
+    <Navigation />
+    <Projects />
+    <CTA />
+    <Contact />
+    <Footer />
+    <ScrollToTop />
+  </div>
+);
+
+export default PortfolioPage;

--- a/src/pages/ServicesPage.tsx
+++ b/src/pages/ServicesPage.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Navigation from '@/components/Navigation';
+import NeonServices from '@/components/NeonServices';
+import CTA from '@/components/CTA';
+import Contact from '@/components/Contact';
+import Footer from '@/components/Footer';
+import ScrollToTop from '@/components/ScrollToTop';
+
+const ServicesPage: React.FC = () => (
+  <div className="min-h-screen">
+    <Navigation />
+    <NeonServices />
+    <CTA />
+    <Contact />
+    <Footer />
+    <ScrollToTop />
+  </div>
+);
+
+export default ServicesPage;


### PR DESCRIPTION
## Summary
- introduce separate AboutPage, ServicesPage and PortfolioPage components
- register new routes in `App.tsx`
- update `Navigation` to navigate between pages using React Router while preserving smooth scrolling

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6884f06f9cc88330bf2debe40d57f250