### PR TITLE
Add meta tags via Helmet and sitemap plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
+        "react-helmet": "^6.1.0",
         "react-hook-form": "^7.53.0",
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
@@ -5381,6 +5382,27 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.60.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.60.0.tgz",
@@ -5490,6 +5512,15 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-smooth": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@radix-ui/react-aspect-ratio": "^1.1.0",
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-checkbox": "^1.1.1",
-    
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-context-menu": "^2.2.1",
     "@radix-ui/react-dialog": "^1.1.2",
@@ -53,6 +52,7 @@
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
+    "react-helmet": "^6.1.0",
     "react-hook-form": "^7.53.0",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -6,4 +6,13 @@
   <url>
     <loc>https://askarsolutions.com/demo</loc>
   </url>
+  <url>
+    <loc>https://askarsolutions.com/services</loc>
+  </url>
+  <url>
+    <loc>https://askarsolutions.com/about</loc>
+  </url>
+  <url>
+    <loc>https://askarsolutions.com/portfolio</loc>
+  </url>
 </urlset>

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,20 +1,29 @@
 import React from 'react';
+import { Helmet } from 'react-helmet';
 import Navigation from '@/components/Navigation';
 import About from '@/components/About';
 import CTA from '@/components/CTA';
 import Contact from '@/components/Contact';
 import Footer from '@/components/Footer';
 import ScrollToTop from '@/components/ScrollToTop';
+import { useLanguage } from '@/contexts/LanguageContext';
 
-const AboutPage: React.FC = () => (
-  <div className="min-h-screen">
-    <Navigation />
-    <About />
-    <CTA />
-    <Contact />
-    <Footer />
-    <ScrollToTop />
-  </div>
-);
+const AboutPage: React.FC = () => {
+  const { t } = useLanguage();
+  return (
+    <div className="min-h-screen">
+      <Helmet>
+        <title>{`${t('aboutTitle')} - ${t('siteTitle')}`}</title>
+        <meta name="description" content={t('aboutDesc')} />
+      </Helmet>
+      <Navigation />
+      <About />
+      <CTA />
+      <Contact />
+      <Footer />
+      <ScrollToTop />
+    </div>
+  );
+};
 
 export default AboutPage;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import { Helmet } from 'react-helmet';
 import Navigation from '@/components/Navigation';
 import HeroSlider from '@/components/HeroSlider';
 import NeonServices from '@/components/NeonServices';
@@ -9,10 +10,16 @@ import CTA from '@/components/CTA';
 import Contact from '@/components/Contact';
 import Footer from '@/components/Footer';
 import ScrollToTop from '@/components/ScrollToTop';
+import { useLanguage } from '@/contexts/LanguageContext';
 
 const Index: React.FC = () => {
+  const { t } = useLanguage();
   return (
     <div className="min-h-screen">
+      <Helmet>
+        <title>{t('siteTitle')}</title>
+        <meta name="description" content={t('siteDescription')} />
+      </Helmet>
       <Navigation />
       <HeroSlider />
       <NeonServices />

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import { Helmet } from 'react-helmet';
 import { useNavigate } from 'react-router-dom';
 import { Home, ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -16,6 +17,10 @@ const NotFound = () => {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-blue-900">
+      <Helmet>
+        <title>{`404 - ${t('siteTitle')}`}</title>
+        <meta name="description" content={t('notFoundDesc')} />
+      </Helmet>
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -1,20 +1,29 @@
 import React from 'react';
+import { Helmet } from 'react-helmet';
 import Navigation from '@/components/Navigation';
 import Projects from '@/components/Projects';
 import CTA from '@/components/CTA';
 import Contact from '@/components/Contact';
 import Footer from '@/components/Footer';
 import ScrollToTop from '@/components/ScrollToTop';
+import { useLanguage } from '@/contexts/LanguageContext';
 
-const PortfolioPage: React.FC = () => (
-  <div className="min-h-screen">
-    <Navigation />
-    <Projects />
-    <CTA />
-    <Contact />
-    <Footer />
-    <ScrollToTop />
-  </div>
-);
+const PortfolioPage: React.FC = () => {
+  const { t } = useLanguage();
+  return (
+    <div className="min-h-screen">
+      <Helmet>
+        <title>{`${t('projectsTitle')} - ${t('siteTitle')}`}</title>
+        <meta name="description" content={t('projectsSubtitle')} />
+      </Helmet>
+      <Navigation />
+      <Projects />
+      <CTA />
+      <Contact />
+      <Footer />
+      <ScrollToTop />
+    </div>
+  );
+};
 
 export default PortfolioPage;

--- a/src/pages/ServicesPage.tsx
+++ b/src/pages/ServicesPage.tsx
@@ -1,20 +1,29 @@
 import React from 'react';
+import { Helmet } from 'react-helmet';
 import Navigation from '@/components/Navigation';
 import NeonServices from '@/components/NeonServices';
 import CTA from '@/components/CTA';
 import Contact from '@/components/Contact';
 import Footer from '@/components/Footer';
 import ScrollToTop from '@/components/ScrollToTop';
+import { useLanguage } from '@/contexts/LanguageContext';
 
-const ServicesPage: React.FC = () => (
-  <div className="min-h-screen">
-    <Navigation />
-    <NeonServices />
-    <CTA />
-    <Contact />
-    <Footer />
-    <ScrollToTop />
-  </div>
-);
+const ServicesPage: React.FC = () => {
+  const { t } = useLanguage();
+  return (
+    <div className="min-h-screen">
+      <Helmet>
+        <title>{`${t('servicesTitle')} - ${t('siteTitle')}`}</title>
+        <meta name="description" content={t('servicesSubtitle')} />
+      </Helmet>
+      <Navigation />
+      <NeonServices />
+      <CTA />
+      <Contact />
+      <Footer />
+      <ScrollToTop />
+    </div>
+  );
+};
 
 export default ServicesPage;

--- a/src/pages/SiteIndex.tsx
+++ b/src/pages/SiteIndex.tsx
@@ -1,12 +1,15 @@
 import React, { useEffect } from 'react';
+import { Helmet } from 'react-helmet';
 import HeroSlider from '@/components/HeroSlider';
 import SitePortfolio from '@/components/SitePortfolio';
 import SiteServices from '@/components/SiteServices';
 import SiteContact from '@/components/SiteContact';
 import SiteFooter from '@/components/SiteFooter';
 import Navigation from '@/components/Navigation';
+import { useLanguage } from '@/contexts/LanguageContext';
 
 const SiteIndex: React.FC = () => {
+  const { t } = useLanguage();
   useEffect(() => {
     document.documentElement.lang = 'ar';
     document.documentElement.dir = 'rtl';
@@ -14,6 +17,10 @@ const SiteIndex: React.FC = () => {
 
   return (
     <div className="font-sans">
+      <Helmet>
+        <title>{t('siteTitle')}</title>
+        <meta name="description" content={t('siteDescription')} />
+      </Helmet>
       <Navigation />
       <HeroSlider />
       <SitePortfolio />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,22 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
+import { promises as fs } from "fs";
 import { componentTagger } from "lovable-tagger";
+
+function generateSitemapPlugin() {
+  return {
+    name: "generate-sitemap",
+    async buildEnd() {
+      const routes = ["/", "/demo", "/services", "/about", "/portfolio"];
+      const urls = routes
+        .map((r) => `  <url>\n    <loc>https://askarsolutions.com${r}</loc>\n  </url>`)
+        .join("\n");
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>`;
+      await fs.writeFile(path.resolve(__dirname, "public", "sitemap.xml"), xml);
+    },
+  };
+}
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -42,7 +57,8 @@ export default defineConfig(({ mode }) => {
     plugins: [
       react(),
       // Only include componentTagger in development
-      ...(isDev ? [componentTagger()] : [])
+      ...(isDev ? [componentTagger()] : []),
+      generateSitemapPlugin(),
     ],
     
     resolve: {


### PR DESCRIPTION
## Summary
- set page titles and descriptions using `react-helmet`
- generate sitemap during Vite build

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688506c2f29083309861660575f1f517