### PR TITLE
Fix component imports after rename

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import Navigation from '@/components/Navigation';
 import HeroSlider from '@/components/HeroSlider';
-import NeonServices from '@/components/NeonServices';
-import Projects from '@/components/Projects';
+import Services from '@/components/Services';
+import Portfolio from '@/components/Portfolio';
 import About from '@/components/About';
 import CTA from '@/components/CTA';
 import Contact from '@/components/Contact';
@@ -32,8 +32,8 @@ const Index: React.FC = () => {
       <Navigation />
       <main id="main-content">
         <HeroSlider />
-        <NeonServices />
-        <Projects />
+        <Services />
+        <Portfolio />
         <About />
         <CTA />
         <Contact />

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import Navigation from '@/components/Navigation';
-import Projects from '@/components/Projects';
+import Portfolio from '@/components/Portfolio';
 import CTA from '@/components/CTA';
 import Contact from '@/components/Contact';
 import Footer from '@/components/Footer';
@@ -28,7 +28,7 @@ const PortfolioPage: React.FC = () => {
 
       <Navigation />
       <main id="main-content">
-        <Projects />
+        <Portfolio />
         <CTA />
         <Contact />
       </main>

--- a/src/pages/ServicesPage.tsx
+++ b/src/pages/ServicesPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import Navigation from '@/components/Navigation';
-import NeonServices from '@/components/NeonServices';
+import Services from '@/components/Services';
 import CTA from '@/components/CTA';
 import Contact from '@/components/Contact';
 import Footer from '@/components/Footer';
@@ -28,7 +28,7 @@ const ServicesPage: React.FC = () => {
 
       <Navigation />
       <main id="main-content">
-        <NeonServices />
+        <Services />
         <CTA />
         <Contact />
       </main>

--- a/src/pages/SiteIndex.tsx
+++ b/src/pages/SiteIndex.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import HeroSlider from '@/components/HeroSlider';
-import SitePortfolio from '@/components/SitePortfolio';
-import SiteServices from '@/components/SiteServices';
-import SiteContact from '@/components/SiteContact';
-import SiteFooter from '@/components/SiteFooter';
+import Portfolio from '@/components/Portfolio';
+import Services from '@/components/Services';
+import Contact from '@/components/Contact';
+import Footer from '@/components/Footer';
 import Navigation from '@/components/Navigation';
 import { useLanguage } from '@/contexts/LanguageContext';
 
@@ -34,11 +34,11 @@ const SiteIndex: React.FC = () => {
       <Navigation />
       <main id="main-content">
         <HeroSlider />
-        <SitePortfolio />
-        <SiteServices />
-        <SiteContact />
+        <Portfolio />
+        <Services />
+        <Contact />
       </main>
-      <SiteFooter />
+      <Footer />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- update pages to import new `Services` and `Portfolio` components
- use renamed components on Arabic site
- ensure Vite build succeeds

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68850cba69848330af6d5e590dd41d6e