### PR TITLE
Add canonical and OG metadata

### DIFF
--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -16,6 +16,17 @@ const AboutPage: React.FC = () => {
       <Helmet>
         <title>{`${t('aboutTitle')} - ${t('siteTitle')}`}</title>
         <meta name="description" content={t('aboutDesc')} />
+        <link rel="canonical" href="https://askarsolutions.com/about" />
+        <meta
+          property="og:title"
+          content={`${t('aboutTitle')} - ${t('siteTitle')}`}
+        />
+        <meta property="og:description" content={t('aboutDesc')} />
+        <meta property="og:url" content="https://askarsolutions.com/about" />
+        <meta
+          property="og:image"
+          content="https://lovable.dev/opengraph-image-p98pqg.png"
+        />
       </Helmet>
 
       <a

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -19,6 +19,14 @@ const Index: React.FC = () => {
       <Helmet>
         <title>{t('siteTitle')}</title>
         <meta name="description" content={t('siteDescription')} />
+        <link rel="canonical" href="https://askarsolutions.com/demo" />
+        <meta property="og:title" content={t('siteTitle')} />
+        <meta property="og:description" content={t('siteDescription')} />
+        <meta property="og:url" content="https://askarsolutions.com/demo" />
+        <meta
+          property="og:image"
+          content="https://lovable.dev/opengraph-image-p98pqg.png"
+        />
       </Helmet>
 
       {/* Skip Link for Accessibility */}

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -22,6 +22,14 @@ const NotFound = () => {
       <Helmet>
         <title>{`404 - ${t('siteTitle')}`}</title>
         <meta name="description" content={t('notFoundDesc')} />
+        <link rel="canonical" href="https://askarsolutions.com/404" />
+        <meta property="og:title" content={`404 - ${t('siteTitle')}`} />
+        <meta property="og:description" content={t('notFoundDesc')} />
+        <meta property="og:url" content="https://askarsolutions.com/404" />
+        <meta
+          property="og:image"
+          content="https://lovable.dev/opengraph-image-p98pqg.png"
+        />
       </Helmet>
 
       <a

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -16,6 +16,17 @@ const PortfolioPage: React.FC = () => {
       <Helmet>
         <title>{`${t('projectsTitle')} - ${t('siteTitle')}`}</title>
         <meta name="description" content={t('projectsSubtitle')} />
+        <link rel="canonical" href="https://askarsolutions.com/portfolio" />
+        <meta
+          property="og:title"
+          content={`${t('projectsTitle')} - ${t('siteTitle')}`}
+        />
+        <meta property="og:description" content={t('projectsSubtitle')} />
+        <meta property="og:url" content="https://askarsolutions.com/portfolio" />
+        <meta
+          property="og:image"
+          content="https://lovable.dev/opengraph-image-p98pqg.png"
+        />
       </Helmet>
 
       {/* Skip link for accessibility */}

--- a/src/pages/ServicesPage.tsx
+++ b/src/pages/ServicesPage.tsx
@@ -16,6 +16,17 @@ const ServicesPage: React.FC = () => {
       <Helmet>
         <title>{`${t('servicesTitle')} - ${t('siteTitle')}`}</title>
         <meta name="description" content={t('servicesSubtitle')} />
+        <link rel="canonical" href="https://askarsolutions.com/services" />
+        <meta
+          property="og:title"
+          content={`${t('servicesTitle')} - ${t('siteTitle')}`}
+        />
+        <meta property="og:description" content={t('servicesSubtitle')} />
+        <meta property="og:url" content="https://askarsolutions.com/services" />
+        <meta
+          property="og:image"
+          content="https://lovable.dev/opengraph-image-p98pqg.png"
+        />
       </Helmet>
 
       {/* Skip Link for Accessibility */}

--- a/src/pages/SiteIndex.tsx
+++ b/src/pages/SiteIndex.tsx
@@ -21,6 +21,14 @@ const SiteIndex: React.FC = () => {
       <Helmet>
         <title>{t('siteTitle')}</title>
         <meta name="description" content={t('siteDescription')} />
+        <link rel="canonical" href="https://askarsolutions.com/" />
+        <meta property="og:title" content={t('siteTitle')} />
+        <meta property="og:description" content={t('siteDescription')} />
+        <meta property="og:url" content="https://askarsolutions.com/" />
+        <meta
+          property="og:image"
+          content="https://lovable.dev/opengraph-image-p98pqg.png"
+        />
       </Helmet>
 
       {/* Skip Link for Accessibility */}


### PR DESCRIPTION
## Summary
- extend each page's `<Helmet>` block with canonical URLs
- add Open Graph tags for title, description, URL and image

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68850d6cbf908330a7a11c48dae5b005