### PR TITLE
Implement neon navbar with scroll spy and back-to-top button

### DIFF
--- a/src/components/BackToTopButton.tsx
+++ b/src/components/BackToTopButton.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import { ChevronUp } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+const easeInOutCubic = (t: number) =>
+  t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+
+const BackToTopButton: React.FC = () => {
+  const [visible, setVisible] = useState(false);
+  const { language } = useLanguage();
+
+  useEffect(() => {
+    const onScroll = () => {
+      setVisible(window.scrollY > 300);
+    };
+    onScroll();
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    const start = window.scrollY || window.pageYOffset;
+    const duration = 700;
+    const startTime = performance.now();
+
+    const scroll = (currentTime: number) => {
+      const elapsed = currentTime - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      const ease = easeInOutCubic(progress);
+      window.scrollTo(0, start - start * ease);
+      if (progress < 1) requestAnimationFrame(scroll);
+    };
+
+    requestAnimationFrame(scroll);
+  };
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.button
+          type="button"
+          aria-label={language !== 'en' ? 'العودة للأعلى' : 'Back to top'}
+          onClick={scrollToTop}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 20 }}
+          transition={{ duration: 0.3 }}
+          className={`fixed bottom-6 ${language !== 'en' ? 'left-6' : 'right-6'} z-40 p-3 rounded-full bg-background/80 backdrop-blur-md text-foreground shadow-elegant hover:bg-background/90 focus:outline-none`}
+        >
+          <ChevronUp className="w-5 h-5" />
+        </motion.button>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default BackToTopButton;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -133,12 +133,16 @@ const Navigation: React.FC = () => {
   return (
     <>
       <a href="#main" className="sr-only focus:not-sr-only">Skip to content</a>
-      <nav
-      aria-label="Main navigation"
-      dir={isRTL ? "rtl" : "ltr"}
-      className={navClass}
-      style={{ height: NAVBAR_HEIGHT }}
-    >   <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-full">
+      <motion.nav
+        aria-label="Main navigation"
+        dir={isRTL ? "rtl" : "ltr"}
+        className={navClass}
+        style={{ height: NAVBAR_HEIGHT }}
+        initial={{ y: -20, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ duration: 0.5 }}
+      >
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-full">
         <div className="flex items-center justify-between h-full">
           {/* Logo */}
           <motion.div whileHover={{ scale: 1.05 }} transition={{ duration: 0.2 }}>
@@ -150,20 +154,15 @@ const Navigation: React.FC = () => {
             {navItems.map((item) => {
               const isActive = activeId === item.href.slice(1);
               return (
-               <motion.button
+                <motion.button
                   key={item.key}
                   onClick={() => handleNavItemClick(item)}
                   whileHover={{ scale: 1.08 }}
                   whileTap={{ scale: 0.95 }}
                   className={cn(
-                    "relative font-semibold text-lg tracking-wide transition-all duration-300",
-                    isActive ? "text-foreground" : "text-muted-foreground hover:text-foreground"
+                    "nav-link font-semibold text-lg tracking-wide",
+                    isActive ? "text-foreground neon-active" : "text-muted-foreground hover:text-foreground"
                   )}
-                  style={{
-                    textShadow: isActive
-                      ? "0 0 12px rgba(255,255,255,0.8), 0 0 24px rgba(255,255,255,0.6)"
-                      : "0 0 6px rgba(255,255,255,0.2)",
-                  }}
                 >
                   {t(item.key)}
                 </motion.button>
@@ -216,30 +215,36 @@ const Navigation: React.FC = () => {
               style={{ top: NAVBAR_HEIGHT }}
             >
               <div className="flex flex-col items-center space-y-8 py-8">
-                {navItems.map((item, index) => (
-                  <motion.button
-                    key={item.key}
-                    onClick={() => handleNavItemClick(item)}
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{
-                      opacity: 1,
-                      y: 0,
-                      transition: { delay: index * 0.1, duration: 0.3, ease: "easeOut" },
-                    }}
-                    className="text-2xl font-semibold text-foreground"
-                    style={{
-                      textShadow: "0 0 8px rgba(255,255,255,0.8), 0 0 20px rgba(255,255,255,0.6)",
-                    }}
-                  >
-                    {t(item.key)}
-                  </motion.button>
-                ))}
+                {navItems.map((item, index) => {
+                  const isActive = activeId === item.href.slice(1);
+                  return (
+                    <motion.button
+                      key={item.key}
+                      onClick={() => handleNavItemClick(item)}
+                      initial={{ opacity: 0, y: 20 }}
+                      animate={{
+                        opacity: 1,
+                        y: 0,
+                        transition: { delay: index * 0.1, duration: 0.3, ease: "easeOut" },
+                      }}
+                      className={cn(
+                        "text-2xl font-semibold",
+                        isActive ? "neon-active" : ""
+                      )}
+                      style={{
+                        textShadow: "0 0 8px rgba(255,255,255,0.8), 0 0 20px rgba(255,255,255,0.6)",
+                      }}
+                    >
+                      {t(item.key)}
+                    </motion.button>
+                  );
+                })}
               </div>
             </motion.div>
           )}
         </AnimatePresence>
       </div>
-    </nav>
+    </motion.nav>
     </>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -461,3 +461,16 @@
     transition-duration: 0.01ms !important;
   }
 }
+.nav-link {
+  @apply relative pb-1 transition-all duration-300 ease-in-out;
+}
+.nav-link::after {
+  content: "";
+  @apply absolute left-0 bottom-0 h-0.5 w-full bg-current transform scale-x-0 origin-left transition-transform duration-300 ease-in-out;
+}
+.nav-link:hover::after {
+  @apply scale-x-100;
+}
+.neon-active {
+  text-shadow: 0 0 8px rgba(63,255,181,0.8), 0 0 16px rgba(63,255,181,0.6);
+}

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -5,7 +5,7 @@ import About from '@/components/About';
 import CTA from '@/components/CTA';
 import Contact from '@/components/Contact';
 import Footer from '@/components/Footer';
-import ScrollToTop from '@/components/ScrollToTop';
+import BackToTopButton from '@/components/BackToTopButton';
 import { useLanguage } from '@/contexts/LanguageContext';
 
 const AboutPage: React.FC = () => {
@@ -32,7 +32,7 @@ const AboutPage: React.FC = () => {
         <Contact />
       </main>
       <Footer />
-      <ScrollToTop />
+      <BackToTopButton />
     </div>
   );
 };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,7 +8,7 @@ import About from '@/components/About';
 import CTA from '@/components/CTA';
 import Contact from '@/components/Contact';
 import Footer from '@/components/Footer';
-import ScrollToTop from '@/components/ScrollToTop';
+import BackToTopButton from '@/components/BackToTopButton';
 import { useLanguage } from '@/contexts/LanguageContext';
 
 const Index: React.FC = () => {
@@ -39,7 +39,7 @@ const Index: React.FC = () => {
         <Contact />
       </main>
       <Footer />
-      <ScrollToTop />
+      <BackToTopButton />
     </div>
   );
 };

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -5,7 +5,7 @@ import Portfolio from '@/components/Portfolio';
 import CTA from '@/components/CTA';
 import Contact from '@/components/Contact';
 import Footer from '@/components/Footer';
-import ScrollToTop from '@/components/ScrollToTop';
+import BackToTopButton from '@/components/BackToTopButton';
 import { useLanguage } from '@/contexts/LanguageContext';
 
 const PortfolioPage: React.FC = () => {
@@ -33,7 +33,7 @@ const PortfolioPage: React.FC = () => {
         <Contact />
       </main>
       <Footer />
-      <ScrollToTop />
+      <BackToTopButton />
     </div>
   );
 };

--- a/src/pages/ServicesPage.tsx
+++ b/src/pages/ServicesPage.tsx
@@ -5,7 +5,7 @@ import Services from '@/components/Services';
 import CTA from '@/components/CTA';
 import Contact from '@/components/Contact';
 import Footer from '@/components/Footer';
-import ScrollToTop from '@/components/ScrollToTop';
+import BackToTopButton from '@/components/BackToTopButton';
 import { useLanguage } from '@/contexts/LanguageContext';
 
 const ServicesPage: React.FC = () => {
@@ -33,7 +33,7 @@ const ServicesPage: React.FC = () => {
         <Contact />
       </main>
       <Footer />
-      <ScrollToTop />
+      <BackToTopButton />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add `BackToTopButton` component with framer-motion fade animations
- highlight active navbar links with neon glow and underline hover effect
- animate navbar entry using framer-motion
- wire new back-to-top button into all pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68854766d3ec833094efe9c705f20fd3