### PR TITLE
Add technologies and FAQ sections

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,23 +1,18 @@
-
-+import React from 'react';
-import { useLanguage } from '@/contexts/LanguageContext'; 
+import React from 'react';
+import Navigation from './layout/Navigation';
 import Footer from './layout/Footer';
-import Navigation from './la+
-ug `yout/Navigation';
+import { useLanguage } from '@/contexts/LanguageContext';
 
 interface LayoutProps {
   children: React.ReactNode;
 }
 
 const Layout: React.FC<LayoutProps> = ({ children }) => {
-  const { dir } = useLanguage();
-
+  const { isRTL } = useLanguage();
   return (
-    <div className="min-h-screen flex flex-col" dir={dir}>
+    <div className="min-h-screen flex flex-col" dir={isRTL ? 'rtl' : 'ltr'}>
       <Navigation />
-      <main className="flex-1">
-        {children}
-      </main>
+      <main className="flex-1">{children}</main>
       <Footer />
     </div>
   );

--- a/src/components/sections/FAQ.tsx
+++ b/src/components/sections/FAQ.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+interface FAQItem {
+  question: { en: string; ar: string; eg: string };
+  answer: { en: string; ar: string; eg: string };
+}
+
+const items: FAQItem[] = [
+  {
+    question: {
+      en: 'What services do you offer?',
+      ar: 'ما هي الخدمات التي تقدمونها؟',
+      eg: 'إيه الخدمات اللي بتقدموها؟',
+    },
+    answer: {
+      en: 'We provide custom software development, mobile apps, and cloud solutions tailored to business needs.',
+      ar: 'نقدم تطوير برمجيات مخصصة وتطبيقات جوال وحلول سحابية مصممة لاحتياجات الأعمال.',
+      eg: 'بنقدم تطوير برمجيات مخصوص، تطبيقات موبايل، وحلول سحابية على حسب احتياجك.',
+    },
+  },
+  {
+    question: {
+      en: 'How can I request a project estimate?',
+      ar: 'كيف يمكنني طلب تقدير لمشروعي؟',
+      eg: 'إزاي أطلب تقدير لمشروعي؟',
+    },
+    answer: {
+      en: 'Simply contact us through the form and our team will get back to you with details.',
+      ar: 'ما عليك سوى التواصل معنا عبر النموذج وسنعود إليك بالتفاصيل.',
+      eg: 'كل اللي عليك تبعتلنا من خلال الفورم، وهنتواصل معاك بالتفاصيل.',
+    },
+  },
+  {
+    question: {
+      en: 'Do you support long-term maintenance?',
+      ar: 'هل تقدمون دعم وصيانة على المدى الطويل؟',
+      eg: 'فيه صيانة ودعم لفترة طويلة؟',
+    },
+    answer: {
+      en: 'Yes, we offer maintenance packages to keep your project running smoothly.',
+      ar: 'نعم، نوفر باقات صيانة لضمان استمرار مشروعك بسلاسة.',
+      eg: 'أيوه، عندنا باقات صيانة عشان مشروعك يفضل شغال تمام.',
+    },
+  },
+];
+
+const FAQ: React.FC = () => {
+  const { language, t } = useLanguage();
+
+  return (
+    <section id="faq" className="py-20 bg-muted">
+      <div className="max-w-5xl mx-auto px-4">
+        <h2 className="text-4xl md:text-5xl font-bold text-center mb-8">
+          {t('faqTitle')}
+        </h2>
+        <p className="text-muted-foreground text-center mb-12">
+          {t('faqSubtitle')}
+        </p>
+        <Accordion type="single" collapsible className="space-y-4">
+          {items.map((item, idx) => (
+            <AccordionItem key={idx} value={`item-${idx}`} className="border border-border rounded-lg">
+              <AccordionTrigger className="px-4">
+                {item.question[language]}
+              </AccordionTrigger>
+              <AccordionContent className="px-4">
+                {item.answer[language]}
+              </AccordionContent>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      </div>
+    </section>
+  );
+};
+
+export default FAQ;

--- a/src/components/sections/Technologies.tsx
+++ b/src/components/sections/Technologies.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '@/components/ui/carousel';
+import { Server, Cloud, Database, Code, Globe, Layers } from 'lucide-react';
+
+interface Tech {
+  name: string;
+  icon: React.ElementType;
+}
+
+const Technologies: React.FC = () => {
+  const { t } = useLanguage();
+
+  const techs: Tech[] = [
+    { name: 'React', icon: Code },
+    { name: 'Node.js', icon: Server },
+    { name: 'GraphQL', icon: Layers },
+    { name: 'AWS', icon: Cloud },
+    { name: 'Docker', icon: Database },
+    { name: 'Global Partners', icon: Globe },
+  ];
+
+  return (
+    <section id="technologies" className="py-20 bg-background">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+        <h2 className="text-4xl md:text-5xl font-bold mb-4">
+          {t('technologiesTitle')}
+        </h2>
+        <p className="text-muted-foreground mb-12 max-w-2xl mx-auto">
+          {t('technologiesSubtitle')}
+        </p>
+        <Carousel className="relative" opts={{ loop: true }}>
+          <CarouselContent className="-ml-4">
+            {techs.map((tech, idx) => {
+              const Icon = tech.icon;
+              return (
+                <CarouselItem key={idx} className="pl-4 basis-1/2 md:basis-1/4 lg:basis-1/6">
+                  <div className="p-6 bg-muted rounded-lg flex flex-col items-center hover:shadow-lg transition-shadow">
+                    <Icon className="w-8 h-8 text-primary mb-2" />
+                    <span className="text-sm font-medium">{tech.name}</span>
+                  </div>
+                </CarouselItem>
+              );
+            })}
+          </CarouselContent>
+          <CarouselPrevious className="-left-6" />
+          <CarouselNext className="-right-6" />
+        </Carousel>
+      </div>
+    </section>
+  );
+};
+
+export default Technologies;

--- a/src/locales/ar.ts
+++ b/src/locales/ar.ts
@@ -96,6 +96,14 @@ export const ar = {
   exploreSolutions: 'استكشف الحلول',
   contactSales: 'اتصل بالمبيعات',
 
+  // Technologies & Partners
+  technologiesTitle: 'التقنيات والشركاء',
+  technologiesSubtitle: 'الأدوات والشركاء الذين يدعمون حلولنا',
+
+  // FAQ Section
+  faqTitle: 'الأسئلة الشائعة',
+  faqSubtitle: 'إجابات على الأسئلة المتكررة حول خدماتنا',
+
   // Meta
   siteTitle: 'أسكار للحلول البرمجية - شريك التكنولوجيا المبتكر',
   siteDescription: 'شركة رائدة في تطوير البرمجيات تقدم حلول ويب وموبايل وسحابية متطورة. حول عملك مع خدماتنا التقنية المتخصصة.',

--- a/src/locales/eg.ts
+++ b/src/locales/eg.ts
@@ -95,6 +95,14 @@ export const eg = {
   joinPartners: 'انضم لشركائنا',
   exploreSolutions: 'استكشف الحلول',
   contactSales: 'كلم المبيعات',
+
+  // Technologies & Partners
+  technologiesTitle: 'التقنيات والشركاء',
+  technologiesSubtitle: 'الأدوات والشركاء اللي بيشغلوا حلولنا',
+
+  // FAQ Section
+  faqTitle: 'أسئلة متكررة',
+  faqSubtitle: 'إجابات على الأسئلة المشهورة عن خدماتنا',
   
   // Meta
   siteTitle: 'أسكار للحلول البرمجية - شريك التكنولوجيا المبدع',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -95,6 +95,14 @@ export const en = {
   joinPartners: 'Join Our Partners',
   exploreSolutions: 'Explore Solutions',
   contactSales: 'Contact Sales',
+
+  // Technologies & Partners
+  technologiesTitle: 'Technologies & Partners',
+  technologiesSubtitle: 'The tools and collaborators powering our solutions',
+
+  // FAQ Section
+  faqTitle: 'Frequently Asked Questions',
+  faqSubtitle: 'Answers to common questions about our services',
   
   // Meta
   siteTitle: 'Askar Software Solutions - Innovative Technology Partner',

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,6 +6,8 @@ import Services from '@/components/sections/Services';
 import Solutions from '@/components/sections/Solutions';
 import Portfolio from '@/components/sections/Portfolio';
 import About from '@/components/sections/About';
+import Technologies from '@/components/sections/Technologies';
+import FAQ from '@/components/sections/FAQ';
 import CTA from '@/components/sections/CTA';
 import Contact from '@/components/sections/Contact';
 import Footer from '@/components/layout/Footer';
@@ -39,6 +41,8 @@ const Index: React.FC = () => {
         <Solutions />
         <Portfolio />
         <About />
+        <Technologies />
+        <FAQ />
         <CTA />
         <Contact />
       </main>

--- a/src/pages/ServicesPage.tsx
+++ b/src/pages/ServicesPage.tsx
@@ -5,7 +5,7 @@ import ServicesSection from '@/components/sections/Services';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { CheckCirc  le, ArrowRight } from 'lucide-react';
+import { CheckCircle, ArrowRight } from 'lucide-react';
 
 const ServicesPage: React.FC = () => {
   const { t } = useLanguage();


### PR DESCRIPTION
## Summary
- add new `Technologies` carousel and `FAQ` accordion sections
- update translations for new sections
- include the new sections on the homepage
- fix ServicesPage icon typo
- clean up `Layout` component

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6885ffa78c408330a99b7711445d973a