### PR TITLE
Polish text color tokens

### DIFF
--- a/src/components/ui/optimized-image.tsx
+++ b/src/components/ui/optimized-image.tsx
@@ -65,7 +65,7 @@ export const OptimizedImage = React.forwardRef<HTMLImageElement, OptimizedImageP
     return (
       <div className={cn('relative overflow-hidden', className)}>
         {placeholder === 'blur' && !isLoaded && (
-          <div className="absolute inset-0 bg-gray-200 dark:bg-gray-800 animate-pulse" />
+          <div className="absolute inset-0 bg-muted animate-pulse dark:bg-muted" />
         )}
         
         <img
@@ -85,8 +85,8 @@ export const OptimizedImage = React.forwardRef<HTMLImageElement, OptimizedImageP
         />
         
         {hasError && (
-          <div className="absolute inset-0 flex items-center justify-center bg-gray-100 dark:bg-gray-800">
-            <div className="text-gray-400 dark:text-gray-600 text-sm">
+          <div className="absolute inset-0 flex items-center justify-center bg-muted">
+            <div className="text-muted-foreground text-sm">
               Image failed to load
             </div>
           </div>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -53,10 +53,10 @@ const NotFound = () => {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: [0.42, 0, 0.58, 1], delay: 0.4 }}
         >
-          <h1 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white mb-4">
+          <h1 className="text-2xl md:text-3xl font-bold text-foreground mb-4">
             {t('notFound')}
           </h1>
-          <p className="text-lg text-gray-600 dark:text-gray-400 mb-8 max-w-md mx-auto">
+          <p className="text-lg text-muted-foreground mb-8 max-w-md mx-auto">
             {t('notFoundDesc')}
           </p>
         </motion.div>


### PR DESCRIPTION
## Summary
- replace gray util classes in OptimizedImage with brand tokens
- clean up NotFound page text colors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68870669fd5c8330afcfadc99f492691