### PR TITLE
Add global pages and theme-aware navbar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,10 @@ import AboutPage from "./pages/AboutPage";
 import ServicesPage from "./pages/ServicesPage";
 import PortfolioPage from "./pages/PortfolioPage";
 import SolutionsPage from "./pages/SolutionsPage";
+import CareersPage from "./pages/CareersPage";
+import DocsPage from "./pages/DocsPage";
+import BlogPage from "./pages/BlogPage";
+import PartnersPage from "./pages/PartnersPage";
 import NotFound from "./pages/NotFound";
 import Layout from "./components/Layout";
 
@@ -33,6 +37,10 @@ const App = () => (
   <Route path="/about" element={<Layout><AboutPage /></Layout>} />
   <Route path="/portfolio" element={<Layout><PortfolioPage isArabic={false} /></Layout>} />
   <Route path="/solutions" element={<Layout><SolutionsPage /></Layout>} />
+  <Route path="/careers" element={<Layout><CareersPage /></Layout>} />
+  <Route path="/docs" element={<Layout><DocsPage /></Layout>} />
+  <Route path="/blog" element={<Layout><BlogPage /></Layout>} />
+  <Route path="/partners" element={<Layout><PartnersPage /></Layout>} />
   <Route path="*" element={<Layout><NotFound /></Layout>} />
 </Routes>
 

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -117,9 +117,11 @@ const Navigation: React.FC = () => {
                   className={cn(
                     "relative px-4 py-2 mx-1 text-sm lg:text-base font-medium rounded-lg",
                     "transition-all duration-300 ease-out",
-                    isScrolled 
+                    isScrolled
                       ? "text-foreground hover:text-primary"
-                      : "text-white hover:text-primary",
+                      : theme === "light"
+                        ? "text-white hover:text-primary"
+                        : "text-foreground hover:text-primary",
                     isActive && "text-primary"
                   )}
                 >
@@ -130,9 +132,11 @@ const Navigation: React.FC = () => {
                       layoutId="activeIndicator"
                       className={cn(
                         "absolute inset-0 rounded-lg",
-                        isScrolled 
-                          ? "bg-primary/10 border border-primary/20" 
-                          : "bg-white/10 border border-white/20"
+                        isScrolled
+                          ? "bg-primary/10 border border-primary/20"
+                          : theme === "light"
+                            ? "bg-white/10 border border-white/20"
+                            : "bg-foreground/10 border border-foreground/20"
                       )}
                       transition={{ duration: 0.3, ease: "easeOut" }}
                     />
@@ -140,9 +144,11 @@ const Navigation: React.FC = () => {
                   
                   <div className={cn(
                     "absolute inset-0 rounded-lg opacity-0 transition-opacity duration-300",
-                    isScrolled 
-                      ? "hover:bg-primary/5 hover:opacity-100" 
-                      : "hover:bg-white/5 hover:opacity-100"
+                    isScrolled
+                      ? "hover:bg-primary/5 hover:opacity-100"
+                      : theme === "light"
+                        ? "hover:bg-white/5 hover:opacity-100"
+                        : "hover:bg-foreground/5 hover:opacity-100"
                   )} />
                 </motion.button>
               );
@@ -159,9 +165,11 @@ const Navigation: React.FC = () => {
                 onClick={toggleTheme}
                 className={cn(
                   "rounded-full w-10 h-10 transition-colors duration-300",
-                  isScrolled 
-                    ? "text-foreground hover:bg-primary/10 hover:text-primary" 
-                    : "text-white hover:bg-white/10"
+                  isScrolled
+                    ? "text-foreground hover:bg-primary/10 hover:text-primary"
+                    : theme === "light"
+                      ? "text-white hover:bg-white/10"
+                      : "text-foreground hover:bg-foreground/10"
                 )}
               >
                 {theme === "light" ? (
@@ -180,9 +188,11 @@ const Navigation: React.FC = () => {
                 onClick={handleLanguageChange}
                 className={cn(
                   "rounded-full text-xs lg:text-sm font-medium transition-colors duration-300",
-                  isScrolled 
-                    ? "text-foreground hover:bg-primary/10 hover:text-primary" 
-                    : "text-white hover:bg-white/10"
+                  isScrolled
+                    ? "text-foreground hover:bg-primary/10 hover:text-primary"
+                    : theme === "light"
+                      ? "text-white hover:bg-white/10"
+                      : "text-foreground hover:bg-foreground/10"
                 )}
               >
                 <Globe className="h-3 w-3 lg:h-4 lg:w-4 mr-1 lg:mr-2" />
@@ -199,9 +209,11 @@ const Navigation: React.FC = () => {
                   onClick={() => setIsOpen(!isOpen)}
                   className={cn(
                     "rounded-full w-10 h-10 transition-colors duration-300",
-                    isScrolled 
-                      ? "text-foreground hover:bg-primary/10" 
-                      : "text-white hover:bg-white/10"
+                    isScrolled
+                      ? "text-foreground hover:bg-primary/10"
+                      : theme === "light"
+                        ? "text-white hover:bg-white/10"
+                        : "text-foreground hover:bg-foreground/10"
                   )}
                 >
                   <AnimatePresence mode="wait">

--- a/src/locales/ar.ts
+++ b/src/locales/ar.ts
@@ -104,6 +104,24 @@ export const ar = {
   faqTitle: 'الأسئلة الشائعة',
   faqSubtitle: 'إجابات على الأسئلة المتكررة حول خدماتنا',
 
+  // Careers Section
+  careers: 'الوظائف',
+  careersTitle: 'انضم إلى فريقنا',
+  careersSubtitle: 'فرص مميزة للنمو معنا.',
+  applyNow: 'قدّم الآن',
+
+  // Documentation Section
+  docsTitle: 'التوثيق',
+  docsSubtitle: 'أدلة وواجهات برمجة التطبيقات للبناء على منصتنا',
+
+  // Blog Section
+  blogTitle: 'المدونة',
+  blogSubtitle: 'أفكار وتحديثات من فريقنا',
+
+  // Partners Section
+  partnersTitle: 'بوابة الشركاء',
+  partnersSubtitle: 'تعاون ونمو مشترك',
+
   // Meta
   siteTitle: 'أسكار للحلول البرمجية - شريك التكنولوجيا المبتكر',
   siteDescription: 'شركة رائدة في تطوير البرمجيات تقدم حلول ويب وموبايل وسحابية متطورة. حول عملك مع خدماتنا التقنية المتخصصة.',

--- a/src/locales/eg.ts
+++ b/src/locales/eg.ts
@@ -103,6 +103,24 @@ export const eg = {
   // FAQ Section
   faqTitle: 'أسئلة متكررة',
   faqSubtitle: 'إجابات على الأسئلة المشهورة عن خدماتنا',
+
+  // Careers Section
+  careers: 'وظائف',
+  careersTitle: 'انضم لفريقنا',
+  careersSubtitle: 'فرص مميزة تكبر معنا.',
+  applyNow: 'قدّم دلوقتي',
+
+  // Documentation Section
+  docsTitle: 'التوثيق',
+  docsSubtitle: 'دليل ومرجع API عشان تبني على منصتنا',
+
+  // Blog Section
+  blogTitle: 'المدونة',
+  blogSubtitle: 'أخبار وتحديثات من فريقنا',
+
+  // Partners Section
+  partnersTitle: 'بوابة الشركاء',
+  partnersSubtitle: 'تعاون ونمو سوا',
   
   // Meta
   siteTitle: 'أسكار للحلول البرمجية - شريك التكنولوجيا المبدع',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -103,6 +103,24 @@ export const en = {
   // FAQ Section
   faqTitle: 'Frequently Asked Questions',
   faqSubtitle: 'Answers to common questions about our services',
+
+  // Careers Section
+  careers: 'Careers',
+  careersTitle: 'Join Our Team',
+  careersSubtitle: 'Exciting opportunities to grow with us.',
+  applyNow: 'Apply Now',
+
+  // Documentation Section
+  docsTitle: 'Documentation',
+  docsSubtitle: 'Guides and API references to build with our platform',
+
+  // Blog Section
+  blogTitle: 'Blog',
+  blogSubtitle: 'Insights and updates from our team',
+
+  // Partners Section
+  partnersTitle: 'Partner Portal',
+  partnersSubtitle: 'Collaborate and grow together',
   
   // Meta
   siteTitle: 'Askar Software Solutions - Innovative Technology Partner',

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import Navigation from '@/components/layout/Navigation';
+import Footer from '@/components/layout/Footer';
+import BackToTopButton from '@/components/layout/BackToTopButton';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+const BlogPage: React.FC = () => {
+  const { t } = useLanguage();
+  return (
+    <div id="main" className="min-h-screen">
+      <Helmet>
+        <title>{`${t('blogTitle')} - ${t('siteTitle')}`}</title>
+        <meta name="description" content={t('blogSubtitle')} />
+      </Helmet>
+
+      <a
+        href="#main-content"
+        className="skip-link absolute left-2 top-2 bg-primary text-white p-2 rounded focus:block focus:z-50"
+      >
+        {t('skipToContent')}
+      </a>
+
+      <Navigation />
+      <main id="main-content" className="py-32 text-center container">
+        <h1 className="text-5xl font-bold mb-4 text-foreground">
+          {t('blogTitle')}
+        </h1>
+        <p className="text-lg text-muted-foreground mb-8">
+          {t('blogSubtitle')}
+        </p>
+      </main>
+      <Footer />
+      <BackToTopButton />
+    </div>
+  );
+};
+
+export default BlogPage;

--- a/src/pages/CareersPage.tsx
+++ b/src/pages/CareersPage.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import Navigation from '@/components/layout/Navigation';
+import Footer from '@/components/layout/Footer';
+import BackToTopButton from '@/components/layout/BackToTopButton';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { Button } from '@/components/ui/button';
+
+const CareersPage: React.FC = () => {
+  const { t } = useLanguage();
+  return (
+    <div id="main" className="min-h-screen">
+      <Helmet>
+        <title>{`${t('careersTitle')} - ${t('siteTitle')}`}</title>
+        <meta name="description" content={t('careersSubtitle')} />
+      </Helmet>
+
+      <a
+        href="#main-content"
+        className="skip-link absolute left-2 top-2 bg-primary text-white p-2 rounded focus:block focus:z-50"
+      >
+        {t('skipToContent')}
+      </a>
+
+      <Navigation />
+      <main id="main-content" className="py-32 text-center container">
+        <h1 className="text-5xl font-bold mb-4 text-foreground">
+          {t('careersTitle')}
+        </h1>
+        <p className="text-lg text-muted-foreground mb-8">
+          {t('careersSubtitle')}
+        </p>
+        <Button size="lg">{t('applyNow')}</Button>
+      </main>
+      <Footer />
+      <BackToTopButton />
+    </div>
+  );
+};
+
+export default CareersPage;

--- a/src/pages/DocsPage.tsx
+++ b/src/pages/DocsPage.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import Navigation from '@/components/layout/Navigation';
+import Footer from '@/components/layout/Footer';
+import BackToTopButton from '@/components/layout/BackToTopButton';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+const DocsPage: React.FC = () => {
+  const { t } = useLanguage();
+  return (
+    <div id="main" className="min-h-screen">
+      <Helmet>
+        <title>{`${t('docsTitle')} - ${t('siteTitle')}`}</title>
+        <meta name="description" content={t('docsSubtitle')} />
+      </Helmet>
+
+      <a
+        href="#main-content"
+        className="skip-link absolute left-2 top-2 bg-primary text-white p-2 rounded focus:block focus:z-50"
+      >
+        {t('skipToContent')}
+      </a>
+
+      <Navigation />
+      <main id="main-content" className="py-32 text-center container">
+        <h1 className="text-5xl font-bold mb-4 text-foreground">
+          {t('docsTitle')}
+        </h1>
+        <p className="text-lg text-muted-foreground mb-8">
+          {t('docsSubtitle')}
+        </p>
+      </main>
+      <Footer />
+      <BackToTopButton />
+    </div>
+  );
+};
+
+export default DocsPage;

--- a/src/pages/PartnersPage.tsx
+++ b/src/pages/PartnersPage.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import Navigation from '@/components/layout/Navigation';
+import Footer from '@/components/layout/Footer';
+import BackToTopButton from '@/components/layout/BackToTopButton';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+const PartnersPage: React.FC = () => {
+  const { t } = useLanguage();
+  return (
+    <div id="main" className="min-h-screen">
+      <Helmet>
+        <title>{`${t('partnersTitle')} - ${t('siteTitle')}`}</title>
+        <meta name="description" content={t('partnersSubtitle')} />
+      </Helmet>
+
+      <a
+        href="#main-content"
+        className="skip-link absolute left-2 top-2 bg-primary text-white p-2 rounded focus:block focus:z-50"
+      >
+        {t('skipToContent')}
+      </a>
+
+      <Navigation />
+      <main id="main-content" className="py-32 text-center container">
+        <h1 className="text-5xl font-bold mb-4 text-foreground">
+          {t('partnersTitle')}
+        </h1>
+        <p className="text-lg text-muted-foreground mb-8">
+          {t('partnersSubtitle')}
+        </p>
+      </main>
+      <Footer />
+      <BackToTopButton />
+    </div>
+  );
+};
+
+export default PartnersPage;


### PR DESCRIPTION
## Summary
- add missing global sections to i18n files
- include placeholder pages for Careers, Docs, Blog, and Partners
- add routes for the new pages
- refine navbar styling so unscrolled state adapts to current theme

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889059f543c8330b18df782b0bb848d