### PR TITLE
Refactor theme tokens

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -1,0 +1,31 @@
+# Design Tokens
+
+This project centralizes all brand colors in CSS variables defined in `src/index.css` and exposed through Tailwind via `tailwind.config.ts`.
+
+## Core Tokens
+- `--brand-primary` / `--brand-secondary` – main accent colors
+- `--brand-accent` – deep blue accent used for titles
+- `--brand-bg` – page background
+- `--brand-surface` – card backgrounds
+- `--brand-glow` – base for glow shadows
+
+## Navigation
+- `--nav-text-light`, `--nav-active-light`
+- `--nav-text-dark`, `--nav-active-dark`
+- `--nav-light-glow`, `--nav-dark-glow`
+- `--nav-shadow`, `--nav-shadow-soft`
+
+## Hero
+- `--hero-gradient-from`, `--hero-gradient-to`
+- `--hero-gradient-dark-from`, `--hero-gradient-dark-to`
+
+## Other
+- `--accent-glow` – neon accent for highlights
+- `--spinner-dark-[1-6]` – dark mode preloader rings
+
+Use these variables with Tailwind's arbitrary values: `bg-[var(--hero-gradient-from)]`, `text-[var(--nav-text-dark)]`, or via the color names added in `tailwind.config.ts` (e.g. `text-nav-dark`).
+
+### Guidelines
+- Avoid hard-coded hex values in components. Reference tokens instead.
+- When adding new UI colors, declare them in `src/index.css` and map them in `tailwind.config.ts`.
+- Ensure sufficient contrast in both light and dark themes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,8 @@
         "tailwindcss": "^3.4.11",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.1",
-        "vite": "^5.4.1"
+        "vite": "^5.4.1",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2876,6 +2877,16 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
@@ -2937,6 +2948,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -3263,6 +3281,121 @@
         "vite": "^4 || ^5 || ^6 || ^7"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3372,6 +3505,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/autoprefixer": {
@@ -3486,6 +3629,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3526,6 +3679,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.1.tgz",
+      "integrity": "sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3541,6 +3711,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -3837,6 +4017,16 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3917,6 +4107,13 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -4177,6 +4374,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4784,6 +4991,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.0.tgz",
+      "integrity": "sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lovable-tagger": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/lovable-tagger/-/lovable-tagger-1.1.8.tgz",
@@ -5091,6 +5305,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -5775,6 +6006,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5805,6 +6043,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -5914,6 +6166,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.0",
@@ -6057,6 +6329,95 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -6345,6 +6706,29 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
@@ -6777,6 +7161,92 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6790,6 +7260,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-
-    
- 
-  "format": "prettier --write .",
-  "test": "vitest"
+    "format": "prettier --write .",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -86,6 +83,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^3.2.4"
   }
 }

--- a/src/components/HeroSlider.tsx
+++ b/src/components/HeroSlider.tsx
@@ -199,7 +199,7 @@ export default function HeroSlider() {
   };
 
   return (
-    <div className="relative w-full h-[100vh] overflow-hidden bg-gradient-to-br from-[#030c2e] to-[#020816]">
+    <div className="relative w-full h-[100vh] overflow-hidden bg-gradient-to-br from-[var(--hero-gradient-from)] to-[var(--hero-gradient-to)]">
       {/* Slide Image */}
 <AnimatePresence mode="wait">
   <motion.img
@@ -270,7 +270,7 @@ export default function HeroSlider() {
                   text-white/90 
                   text-xl sm:text-3xl md:text-5xl 
                   font-black 
-                  drop-shadow-[0_3px_20px_rgba(64,168,255,0.30)]
+                  drop-shadow-[0_3px_20px_hsl(var(--brand-glow)/0.3)]
                   tracking-tight mb-2
                   animate-pulse
                   ${isRTL ? "text-right" : "text-left"}

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -12,11 +12,11 @@ import { cn } from "@/lib/utils";
 const NAVBAR_HEIGHT = 72;
 const SCROLL_THRESHOLD = 10; // اعتبر فوق 10px ليس Hero
 
-// ألوان مشعة (قمري)
-const lunarWhite = "#e6ecfa";
-const lunarActive = "#fafdff";
-const darkNavText = "#b8c3d6";
-const darkNavActive = "#eaf3ff";
+// Theme tokens
+const NAV_LIGHT = "var(--nav-text-light)";
+const NAV_LIGHT_ACTIVE = "var(--nav-active-light)";
+const NAV_DARK = "var(--nav-text-dark)";
+const NAV_DARK_ACTIVE = "var(--nav-active-dark)";
 
 export default function Navigation() {
   const [isOpen, setIsOpen] = useState(false);
@@ -61,9 +61,16 @@ export default function Navigation() {
 
   // دالة لتحديد لون النص (مشع في الأعلى/مناسب للأسفل)
   const getNavTextColor = (isActive: boolean) => {
-    if (isHero) return isActive ? lunarActive : lunarWhite;
-    if (theme === "light") return ""; // استخدم tailwind الافتراضي
-    return isActive ? darkNavActive : darkNavText;
+    if (isHero) return isActive ? NAV_LIGHT_ACTIVE : NAV_LIGHT;
+    if (theme === "light") return ""; // tailwind default
+    return isActive ? NAV_DARK_ACTIVE : NAV_DARK;
+  };
+
+  const getGlow = () => {
+    if (!isHero) return "none";
+    return theme === "light"
+      ? `drop-shadow(0 0 8px var(--nav-light-glow))`
+      : `drop-shadow(0 0 8px var(--nav-dark-glow))`;
   };
 
   // متغيرات قائمة الموبايل
@@ -120,7 +127,7 @@ export default function Navigation() {
                   whileTap={{ scale: 0.97 }}
                   style={{
                     color: getNavTextColor(isActive),
-                    textShadow: isHero ? "0 0 9px #b7c6e3a0" : "none",
+                    textShadow: isHero ? `0 0 9px var(--nav-shadow)` : "none",
                     fontWeight: isActive ? 700 : 500,
                   }}
                   className={cn(
@@ -145,7 +152,7 @@ export default function Navigation() {
                 onClick={toggleTheme}
                 style={{
                   color: getNavTextColor(false),
-                  filter: isHero ? "drop-shadow(0 0 8px #e6ecfa70)" : "none",
+                  filter: getGlow(),
                 }}
                 className={cn(
                   "rounded-full w-10 h-10 transition-colors duration-300"
@@ -166,7 +173,7 @@ export default function Navigation() {
                 onClick={handleLanguageChange}
                 style={{
                   color: getNavTextColor(false),
-                  filter: isHero ? "drop-shadow(0 0 7px #e6ecfa70)" : "none",
+                  filter: getGlow(),
                   fontWeight: 600,
                 }}
                 className={cn(
@@ -186,7 +193,7 @@ export default function Navigation() {
                   onClick={() => setIsOpen(!isOpen)}
                   style={{
                     color: getNavTextColor(false),
-                    filter: isHero ? "drop-shadow(0 0 8px #e6ecfa80)" : "none"
+                    filter: getGlow(),
                   }}
                   className={cn("rounded-full w-10 h-10 transition-colors duration-300")}
                 >
@@ -234,8 +241,8 @@ export default function Navigation() {
                       whileTap={{ scale: 0.95 }}
                       style={{
                         color: getNavTextColor(isActive),
-                        textShadow: isHero ? "0 0 9px #e6ecfa60" : "none",
-                        fontWeight: isActive ? 700 : 600
+                        textShadow: isHero ? `0 0 9px var(--nav-shadow-soft)` : "none",
+                        fontWeight: isActive ? 700 : 600,
                       }}
                       className={cn(
                         "relative text-2xl font-semibold transition-all duration-300",

--- a/src/components/sections/ServicesSection/ServicesSection.tsx
+++ b/src/components/sections/ServicesSection/ServicesSection.tsx
@@ -59,7 +59,7 @@ const ServicesSection: React.FC = () => {
             whileInView={{ scaleX: 1 }}
             viewport={{ once: true }}
             transition={{ duration: 0.8 }}
-            className="absolute left-0 -bottom-1 h-1 w-full origin-left bg-[#3fffB5]"
+            className="absolute left-0 -bottom-1 h-1 w-full origin-left bg-[var(--accent-glow)]"
           />
         </motion.h2>
 

--- a/src/components/ui/Preloader.tsx
+++ b/src/components/ui/Preloader.tsx
@@ -15,16 +15,16 @@ const Preloader: React.FC<PreloaderProps> = ({ onComplete }) => {
 
   return (
     <section className="h-screen w-full py-20 relative flex md:flex-row flex-col justify-center items-center gap-10 bg-gray-900 dark:bg-black">
-      <div className="fixed inset-0 z-50 bg-gradient-to-br from-[#030c2e] to-[#020816] dark:bg-gradient-to-br from-[#1e293b] to-[#0f172a] flex items-center justify-center">
+      <div className="fixed inset-0 z-50 bg-gradient-to-br from-[var(--hero-gradient-from)] to-[var(--hero-gradient-to)] dark:from-[var(--hero-gradient-dark-from)] dark:to-[var(--hero-gradient-dark-to)] flex items-center justify-center">
         <div className="flex flex-col items-center gap-4">
           <div className="w-full h-full flex justify-center items-center">
             {/* Spinner colors for day and night */}
-            <div className="absolute animate-spin h-[16rem] w-[16rem] rounded-full border-tr-4 border-b-4 border-[#36B3F5] dark:border-[#004C7C]"></div>
-            <div className="absolute animate-spin h-[14rem] w-[14rem] rounded-full border-tl-4 border-b-4 border-[#81D4FA] dark:border-[#0066CC]"></div>
-            <div className="absolute animate-spin h-[12rem] w-[12rem] rounded-full border-tr-4 border-b-4 border-[#004C7C] dark:border-[#2C3E50]"></div>
-            <div className="absolute animate-spin h-[10rem] w-[10rem] rounded-full border-tl-4 border-b-4 border-[#36B3F5] dark:border-[#3498DB]"></div>
-            <div className="absolute animate-spin h-[8rem] w-[8rem] rounded-full border-tr-4 border-b-4 border-[#81D4FA] dark:border-[#2980B9]"></div>
-            <div className="absolute animate-spin h-[6rem] w-[6rem] rounded-full border-tl-4 border-b-4 border-[#004C7C] dark:border-[#1ABC9C]"></div>
+            <div className="absolute animate-spin h-[16rem] w-[16rem] rounded-full border-tr-4 border-b-4 border-[hsl(var(--brand-primary))] dark:border-[var(--spinner-dark-1)]"></div>
+            <div className="absolute animate-spin h-[14rem] w-[14rem] rounded-full border-tl-4 border-b-4 border-[hsl(var(--brand-secondary))] dark:border-[var(--spinner-dark-2)]"></div>
+            <div className="absolute animate-spin h-[12rem] w-[12rem] rounded-full border-tr-4 border-b-4 border-[hsl(var(--brand-accent))] dark:border-[var(--spinner-dark-3)]"></div>
+            <div className="absolute animate-spin h-[10rem] w-[10rem] rounded-full border-tl-4 border-b-4 border-[hsl(var(--brand-primary))] dark:border-[var(--spinner-dark-4)]"></div>
+            <div className="absolute animate-spin h-[8rem] w-[8rem] rounded-full border-tr-4 border-b-4 border-[hsl(var(--brand-secondary))] dark:border-[var(--spinner-dark-5)]"></div>
+            <div className="absolute animate-spin h-[6rem] w-[6rem] rounded-full border-tl-4 border-b-4 border-[hsl(var(--brand-accent))] dark:border-[var(--spinner-dark-6)]"></div>
 
             <div className="rounded-full h-28 w-28 animate-bounce flex items-center justify-center font-semibold text-xl text-white">
               Loading...

--- a/src/index.css
+++ b/src/index.css
@@ -42,6 +42,27 @@
     --glass-border: 201 86% 58% / 0.2;     /* Sky blue glass border */
     --spring-glow: 201 86% 58% / 0.4;      /* Soft spring glow */
 
+    /* Navigation System */
+    --nav-text-light: #e6ecfa;             /* Light nav text */
+    --nav-active-light: #fafdff;           /* Active link on hero */
+    --nav-light-glow: #e6ecfa70;           /* Glow for icons */
+    --nav-text-dark: #b8c3d6;              /* Dark mode nav text */
+    --nav-active-dark: #eaf3ff;            /* Dark mode active link */
+    --nav-dark-glow: #e6ecfa80;            /* Dark mode glow */
+    --nav-shadow: #b7c6e3a0;               /* Light text shadow */
+    --nav-shadow-soft: #e6ecfa60;          /* Softer shadow for mobile */
+
+    /* Hero Background */
+    --hero-gradient-from: #030c2e;
+    --hero-gradient-to: #020816;
+    --accent-glow: #3fffb5;
+    --spinner-dark-1: #004C7C;
+    --spinner-dark-2: #0066CC;
+    --spinner-dark-3: #2C3E50;
+    --spinner-dark-4: #3498DB;
+    --spinner-dark-5: #2980B9;
+    --spinner-dark-6: #1ABC9C;
+
     /* ============= SEMANTIC TOKENS - LIGHT MODE ============= */
     --background: var(--brand-bg);
     --foreground: var(--text-base);        /* High contrast navy text */
@@ -118,6 +139,11 @@
     /* Dark Glass Effects */
     --glass-bg: 0 0% 100% / 0.02;         /* Very subtle white overlay */
     --glass-border: 0 0% 100% / 0.05;     /* Subtle white border */
+
+    /* Navigation Dark overrides (reuse same values) */
+
+    --hero-gradient-dark-from: #1e293b;
+    --hero-gradient-dark-to: #0f172a;
 
     /* Dark Sidebar */
     --sidebar-background: 240 5.9% 10%;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -96,7 +96,15 @@ export default {
 
 				// Glass effects
 				'glass-bg': 'hsl(var(--glass-bg))',
-				'glass-border': 'hsl(var(--glass-border))',
+        'glass-border': 'hsl(var(--glass-border))',
+
+        // Navigation colors
+        'nav-light': 'var(--nav-text-light)',
+        'nav-light-active': 'var(--nav-active-light)',
+        'nav-dark': 'var(--nav-text-dark)',
+        'nav-dark-active': 'var(--nav-active-dark)',
+        'hero-from': 'var(--hero-gradient-from)',
+        'hero-to': 'var(--hero-gradient-to)',
 
 				// Status colors
                                 destructive: {


### PR DESCRIPTION
## Summary
- centralize color tokens in `index.css`
- expose navigation and hero variables through Tailwind
- refactor `Navigation`, `HeroSlider`, `Preloader` and services styles to use the tokens
- document available tokens
- add Vitest so `npm test` runs

## Testing
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688aaf6948188330b8db29561e1f1b14