### PR TITLE
Improve Social Proof section responsiveness

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -569,3 +569,20 @@
     transform: translateX(-50%);
   }
 }
+
+/* Marquee animation for scrolling logos */
+@keyframes marquee {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+@keyframes marquee-rtl {
+  from { transform: translateX(0); }
+  to { transform: translateX(50%); }
+}
+.animate-marquee {
+  animation: marquee 30s linear infinite;
+}
+.animate-marquee-rtl {
+  animation: marquee-rtl 30s linear infinite;
+}
+

--- a/src/pages/SocialProofSection.tsx
+++ b/src/pages/SocialProofSection.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { Star, Quote } from 'lucide-react';
+import React from 'react'
+import { Star, Quote } from 'lucide-react'
+import clsx from 'clsx'
 
 interface SocialProofSectionProps {
   isArabic: boolean;
@@ -64,27 +65,36 @@ const SocialProofSection: React.FC<SocialProofSectionProps> = ({ isArabic }) => 
   const sectionTitle = isArabic ? 'عملاؤنا يثقون بنا' : 'Our Clients Trust Us';
 
   return (
-    <section className="py-20 bg-background">
-      <div className="container mx-auto px-6">
+    <section
+      dir={isArabic ? 'rtl' : 'ltr'}
+      className="py-20 md:py-28 bg-gradient-to-b from-background to-muted/50"
+    >
+      <div className="container">
         {/* Section Title */}
-        <div className={`text-center mb-16 ${isArabic ? 'rtl' : 'ltr'}`}>
-          <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl md:text-4xl font-bold font-heading text-foreground">
             {sectionTitle}
           </h2>
         </div>
 
         {/* Client Logos Carousel */}
-        <div className="mb-20 overflow-hidden">
-          <div className="flex animate-scroll space-x-12 md:space-x-16">
+        <div className="mb-20 overflow-hidden relative">
+          <div
+            className={clsx(
+              'flex w-max items-center',
+              isArabic ? 'animate-marquee-rtl' : 'animate-marquee',
+              'gap-8 sm:gap-12 md:gap-16'
+            )}
+          >
             {[...clients, ...clients].map((client, index) => (
               <div
                 key={index}
-                className="flex items-center justify-center min-w-[120px] h-16 bg-card border border-border rounded-lg shadow-card hover:shadow-elegant transition-all duration-300 group"
+                className="flex min-w-[8rem] sm:min-w-[9rem] h-16 items-center justify-center gap-2 bg-card border border-border rounded-2xl shadow-md hover:shadow-elegant transition-all"
               >
-                <div className="text-2xl group-hover:scale-110 transition-transform duration-300">
+                <div className="text-2xl sm:text-3xl group-hover:scale-110 transition-transform">
                   {client.logo}
                 </div>
-                <span className="ml-2 font-medium text-foreground text-sm">
+                <span className="font-medium text-sm text-foreground break-words min-w-0">
                   {client.name}
                 </span>
               </div>
@@ -93,32 +103,32 @@ const SocialProofSection: React.FC<SocialProofSectionProps> = ({ isArabic }) => 
         </div>
 
         {/* Testimonials */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
           {testimonials.map((testimonial, index) => (
             <div
               key={index}
-              className="bg-card border border-border rounded-xl p-6 shadow-card hover:shadow-elegant transition-all duration-300 group"
+              className="bg-card border border-border rounded-2xl p-6 shadow-md hover:shadow-elegant transition-all min-w-0"
             >
               {/* Quote Icon */}
               <div className="flex items-center justify-between mb-4">
-                <Quote className="w-8 h-8 text-primary group-hover:scale-110 transition-transform duration-300" />
-                <div className="flex items-center space-x-1">
+                <Quote className="w-6 h-6 sm:w-8 sm:h-8 text-primary group-hover:scale-110 transition-transform" />
+                <div className="flex items-center gap-1 sm:gap-2">
                   {[...Array(testimonial.rating)].map((_, starIndex) => (
                     <Star
                       key={starIndex}
-                      className="w-4 h-4 text-yellow-400 fill-current"
+                      className="w-4 h-4 sm:w-5 sm:h-5 text-yellow-400 fill-current"
                     />
                   ))}
                 </div>
               </div>
 
               {/* Testimonial Text */}
-              <p className={`text-foreground mb-6 leading-relaxed ${isArabic ? 'text-right' : 'text-left'}`}>
+              <p className={`text-foreground mb-6 leading-relaxed break-words ${isArabic ? 'text-right' : 'text-left'}`}>
                 "{testimonial.text}"
               </p>
 
               {/* Author Info */}
-              <div className={`border-t border-border pt-4 ${isArabic ? 'text-right' : 'text-left'}`}>
+              <div className={`border-t border-border pt-4 mt-4 ${isArabic ? 'text-right' : 'text-left'}`}>
                 <div className="font-semibold text-foreground">
                   {testimonial.author}
                 </div>
@@ -135,28 +145,28 @@ const SocialProofSection: React.FC<SocialProofSectionProps> = ({ isArabic }) => 
 
         {/* Trust Indicators */}
         <div className="mt-20 text-center">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
-            <div className="text-center">
-              <div className="text-3xl font-bold text-primary mb-2">150+</div>
-              <div className="text-muted-foreground text-sm">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-6 sm:gap-8">
+            <div className="flex flex-col items-center justify-center space-y-1">
+              <div className="text-3xl font-bold text-primary">150+</div>
+              <div className="text-sm text-muted-foreground break-words">
                 {isArabic ? 'عميل راضٍ' : 'Happy Clients'}
               </div>
             </div>
-            <div className="text-center">
-              <div className="text-3xl font-bold text-primary mb-2">98%</div>
-              <div className="text-muted-foreground text-sm">
+            <div className="flex flex-col items-center justify-center space-y-1">
+              <div className="text-3xl font-bold text-primary">98%</div>
+              <div className="text-sm text-muted-foreground break-words">
                 {isArabic ? 'معدل النجاح' : 'Success Rate'}
               </div>
             </div>
-            <div className="text-center">
-              <div className="text-3xl font-bold text-primary mb-2">24/7</div>
-              <div className="text-muted-foreground text-sm">
+            <div className="flex flex-col items-center justify-center space-y-1">
+              <div className="text-3xl font-bold text-primary">24/7</div>
+              <div className="text-sm text-muted-foreground break-words">
                 {isArabic ? 'دعم فني' : 'Technical Support'}
               </div>
             </div>
-            <div className="text-center">
-              <div className="text-3xl font-bold text-primary mb-2">5+</div>
-              <div className="text-muted-foreground text-sm">
+            <div className="flex flex-col items-center justify-center space-y-1">
+              <div className="text-3xl font-bold text-primary">5+</div>
+              <div className="text-sm text-muted-foreground break-words">
                 {isArabic ? 'سنوات خبرة' : 'Years Experience'}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add marquee keyframes and animation utilities
- overhaul SocialProofSection with responsive layouts
- make logos auto-scroll and adapt to RTL
- refine testimonials grid and trust stats layout

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ae8f3fb848330bb3bc80069a24013