### PR TITLE
Add headless CMS integration with dynamic pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_CMS_BASE_URL=http://localhost:1337

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variables
+.env

--- a/docs/cms-setup.md
+++ b/docs/cms-setup.md
@@ -1,0 +1,25 @@
+# CMS Setup
+
+This project uses **Strapi** as the headless CMS. Configure the CMS base URL in `.env` using `VITE_CMS_BASE_URL`.
+
+## Content Models
+
+### Blog
+- `title` (Text)
+- `slug` (UID)
+- `summary` (Text)
+- `content` (Rich Text)
+- `publishedAt` (DateTime)
+
+### Careers
+- `title` (Text)
+- `slug` (UID)
+- `location` (Text)
+- `description` (Rich Text)
+- `open` (Boolean)
+
+### Partners
+- `name` (Text)
+- `logo` (Media)
+- `description` (Rich Text)
+- `website` (Text)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,9 @@ const CareersPage = lazy(() => import("./pages/CareersPage"));
 const DocsPage = lazy(() => import("./pages/DocsPage"));
 const BlogPage = lazy(() => import("./pages/BlogPage"));
 const PartnersPage = lazy(() => import("./pages/PartnersPage"));
+const BlogPostPage = lazy(() => import("./pages/BlogPostPage"));
+const CareerPostPage = lazy(() => import("./pages/CareerPostPage"));
+const PartnerPage = lazy(() => import("./pages/PartnerPage"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 import Layout from "./components/Layout";
 
@@ -46,9 +49,12 @@ const App = () => (
   <Route path="/portfolio" element={<Layout><PortfolioPage isArabic={false} /></Layout>} />
   <Route path="/solutions" element={<Layout><SolutionsPage /></Layout>} />
   <Route path="/careers" element={<Layout><CareersPage /></Layout>} />
+  <Route path="/careers/:id" element={<Layout><CareerPostPage /></Layout>} />
   <Route path="/docs" element={<Layout><DocsPage /></Layout>} />
   <Route path="/blog" element={<Layout><BlogPage /></Layout>} />
+  <Route path="/blog/:id" element={<Layout><BlogPostPage /></Layout>} />
   <Route path="/partners" element={<Layout><PartnersPage /></Layout>} />
+  <Route path="/partners/:id" element={<Layout><PartnerPage /></Layout>} />
   <Route path="*" element={<Layout><NotFound /></Layout>} />
 </Routes>
             </Suspense>

--- a/src/lib/cms.ts
+++ b/src/lib/cms.ts
@@ -1,0 +1,40 @@
+export const CMS_BASE_URL = import.meta.env.VITE_CMS_BASE_URL || '';
+
+export interface BlogPost {
+  id: number;
+  title: string;
+  summary?: string;
+  content?: string;
+}
+
+export interface CareerPost {
+  id: number;
+  title: string;
+  location?: string;
+  description?: string;
+}
+
+export interface Partner {
+  id: number;
+  name: string;
+  description?: string;
+}
+
+async function fetchJson<T>(endpoint: string): Promise<T> {
+  const res = await fetch(`${CMS_BASE_URL}${endpoint}`);
+  if (!res.ok) throw new Error('Failed to fetch data');
+  return res.json();
+}
+
+export const fetchBlogPosts = () => fetchJson<BlogPost[]>('/api/blogs');
+export const fetchCareerPosts = () => fetchJson<CareerPost[]>('/api/careers');
+export const fetchPartners = () => fetchJson<Partner[]>('/api/partners');
+
+export const fetchBlogPost = (id: string) =>
+  fetchJson<BlogPost>(`/api/blogs/${id}`);
+
+export const fetchCareerPost = (id: string) =>
+  fetchJson<CareerPost>(`/api/careers/${id}`);
+
+export const fetchPartner = (id: string) =>
+  fetchJson<Partner>(`/api/partners/${id}`);

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
+import { useQuery } from '@tanstack/react-query';
 import Navigation from '@/components/layout/Navigation';
 import Footer from '@/components/layout/Footer';
 import BackToTopButton from '@/components/layout/BackToTopButton';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { fetchBlogPosts, type BlogPost } from '@/lib/cms';
 
 const BlogPage: React.FC = () => {
   const { t } = useLanguage();
+  const { data, isLoading, error } = useQuery<BlogPost[]>({
+    queryKey: ['blogPosts'],
+    queryFn: fetchBlogPosts,
+  });
+
   return (
     <div id="main" className="min-h-screen">
       <Helmet>
@@ -29,6 +36,22 @@ const BlogPage: React.FC = () => {
         <p className="text-lg text-muted-foreground mb-8">
           {t('blogSubtitle')}
         </p>
+        {isLoading && <p>Loading...</p>}
+        {error && <p>Failed to load blog posts</p>}
+        {data && (
+          <ul className="space-y-4 mt-8">
+            {data.map((post) => (
+              <li key={post.id} className="text-left">
+                <h2 className="text-2xl font-semibold text-foreground">
+                  {post.title}
+                </h2>
+                {post.summary && (
+                  <p className="text-muted-foreground">{post.summary}</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
       </main>
       <Footer />
       <BackToTopButton />

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import Navigation from '@/components/layout/Navigation';
+import Footer from '@/components/layout/Footer';
+import BackToTopButton from '@/components/layout/BackToTopButton';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { fetchBlogPost, type BlogPost } from '@/lib/cms';
+
+const BlogPostPage: React.FC = () => {
+  const { id } = useParams();
+  const { t } = useLanguage();
+  const { data, isLoading, error } = useQuery<BlogPost>({
+    queryKey: ['blogPost', id],
+    queryFn: () => fetchBlogPost(id as string),
+    enabled: !!id,
+  });
+
+  return (
+    <div id="main" className="min-h-screen">
+      <Helmet>
+        <title>{`${t('blogTitle')} - ${t('siteTitle')}`}</title>
+        <meta name="description" content={t('blogSubtitle')} />
+      </Helmet>
+      <a
+        href="#main-content"
+        className="skip-link absolute left-2 top-2 bg-primary text-white p-2 rounded focus:block focus:z-50"
+      >
+        {t('skipToContent')}
+      </a>
+      <Navigation />
+      <main id="main-content" className="py-32 container">
+        {isLoading && <p>Loading...</p>}
+        {error && <p>Failed to load post</p>}
+        {data && (
+          <article>
+            <h1 className="text-5xl font-bold mb-4 text-foreground">{data.title}</h1>
+            {data.content && (
+              <div className="prose" dangerouslySetInnerHTML={{ __html: data.content }} />
+            )}
+          </article>
+        )}
+      </main>
+      <Footer />
+      <BackToTopButton />
+    </div>
+  );
+};
+
+export default BlogPostPage;

--- a/src/pages/CareerPostPage.tsx
+++ b/src/pages/CareerPostPage.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import Navigation from '@/components/layout/Navigation';
+import Footer from '@/components/layout/Footer';
+import BackToTopButton from '@/components/layout/BackToTopButton';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { fetchCareerPost, type CareerPost } from '@/lib/cms';
+
+const CareerPostPage: React.FC = () => {
+  const { id } = useParams();
+  const { t } = useLanguage();
+  const { data, isLoading, error } = useQuery<CareerPost>({
+    queryKey: ['careerPost', id],
+    queryFn: () => fetchCareerPost(id as string),
+    enabled: !!id,
+  });
+
+  return (
+    <div id="main" className="min-h-screen">
+      <Helmet>
+        <title>{`${t('careersTitle')} - ${t('siteTitle')}`}</title>
+        <meta name="description" content={t('careersSubtitle')} />
+      </Helmet>
+      <a
+        href="#main-content"
+        className="skip-link absolute left-2 top-2 bg-primary text-white p-2 rounded focus:block focus:z-50"
+      >
+        {t('skipToContent')}
+      </a>
+      <Navigation />
+      <main id="main-content" className="py-32 container">
+        {isLoading && <p>Loading...</p>}
+        {error && <p>Failed to load job</p>}
+        {data && (
+          <article>
+            <h1 className="text-5xl font-bold mb-4 text-foreground">{data.title}</h1>
+            {data.description && (
+              <div className="prose" dangerouslySetInnerHTML={{ __html: data.description }} />
+            )}
+          </article>
+        )}
+      </main>
+      <Footer />
+      <BackToTopButton />
+    </div>
+  );
+};
+
+export default CareerPostPage;

--- a/src/pages/CareersPage.tsx
+++ b/src/pages/CareersPage.tsx
@@ -1,13 +1,19 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
+import { useQuery } from '@tanstack/react-query';
 import Navigation from '@/components/layout/Navigation';
 import Footer from '@/components/layout/Footer';
 import BackToTopButton from '@/components/layout/BackToTopButton';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { Button } from '@/components/ui/button';
+import { fetchCareerPosts, type CareerPost } from '@/lib/cms';
 
 const CareersPage: React.FC = () => {
   const { t } = useLanguage();
+  const { data, isLoading, error } = useQuery<CareerPost[]>({
+    queryKey: ['careerPosts'],
+    queryFn: fetchCareerPosts,
+  });
   return (
     <div id="main" className="min-h-screen">
       <Helmet>
@@ -30,7 +36,25 @@ const CareersPage: React.FC = () => {
         <p className="text-lg text-muted-foreground mb-8">
           {t('careersSubtitle')}
         </p>
-        <Button size="lg">{t('applyNow')}</Button>
+        {isLoading && <p>Loading...</p>}
+        {error && <p>Failed to load jobs</p>}
+        {data && (
+          <ul className="space-y-4 mt-8">
+            {data.map((career) => (
+              <li key={career.id} className="text-left">
+                <h2 className="text-2xl font-semibold text-foreground">
+                  {career.title}
+                </h2>
+                {career.location && (
+                  <p className="text-muted-foreground">{career.location}</p>
+                )}
+                <Button size="sm" className="mt-2">
+                  {t('applyNow')}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
       </main>
       <Footer />
       <BackToTopButton />

--- a/src/pages/PartnerPage.tsx
+++ b/src/pages/PartnerPage.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import Navigation from '@/components/layout/Navigation';
+import Footer from '@/components/layout/Footer';
+import BackToTopButton from '@/components/layout/BackToTopButton';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { fetchPartner, type Partner } from '@/lib/cms';
+
+const PartnerPage: React.FC = () => {
+  const { id } = useParams();
+  const { t } = useLanguage();
+  const { data, isLoading, error } = useQuery<Partner>({
+    queryKey: ['partner', id],
+    queryFn: () => fetchPartner(id as string),
+    enabled: !!id,
+  });
+
+  return (
+    <div id="main" className="min-h-screen">
+      <Helmet>
+        <title>{`${t('partnersTitle')} - ${t('siteTitle')}`}</title>
+        <meta name="description" content={t('partnersSubtitle')} />
+      </Helmet>
+      <a
+        href="#main-content"
+        className="skip-link absolute left-2 top-2 bg-primary text-white p-2 rounded focus:block focus:z-50"
+      >
+        {t('skipToContent')}
+      </a>
+      <Navigation />
+      <main id="main-content" className="py-32 container">
+        {isLoading && <p>Loading...</p>}
+        {error && <p>Failed to load partner</p>}
+        {data && (
+          <article>
+            <h1 className="text-5xl font-bold mb-4 text-foreground">{data.name}</h1>
+            {data.description && (
+              <div className="prose" dangerouslySetInnerHTML={{ __html: data.description }} />
+            )}
+          </article>
+        )}
+      </main>
+      <Footer />
+      <BackToTopButton />
+    </div>
+  );
+};
+
+export default PartnerPage;

--- a/src/pages/PartnersPage.tsx
+++ b/src/pages/PartnersPage.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
+import { useQuery } from '@tanstack/react-query';
 import Navigation from '@/components/layout/Navigation';
 import Footer from '@/components/layout/Footer';
 import BackToTopButton from '@/components/layout/BackToTopButton';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { fetchPartners, type Partner } from '@/lib/cms';
 
 const PartnersPage: React.FC = () => {
   const { t } = useLanguage();
+  const { data, isLoading, error } = useQuery<Partner[]>({
+    queryKey: ['partners'],
+    queryFn: fetchPartners,
+  });
   return (
     <div id="main" className="min-h-screen">
       <Helmet>
@@ -29,6 +35,22 @@ const PartnersPage: React.FC = () => {
         <p className="text-lg text-muted-foreground mb-8">
           {t('partnersSubtitle')}
         </p>
+        {isLoading && <p>Loading...</p>}
+        {error && <p>Failed to load partners</p>}
+        {data && (
+          <ul className="space-y-4 mt-8">
+            {data.map((partner) => (
+              <li key={partner.id} className="text-left">
+                <h2 className="text-2xl font-semibold text-foreground">
+                  {partner.name}
+                </h2>
+                {partner.description && (
+                  <p className="text-muted-foreground">{partner.description}</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
       </main>
       <Footer />
       <BackToTopButton />


### PR DESCRIPTION
## Summary
- integrate Strapi CMS models for Blog, Careers and Partners
- fetch content using new helper `cms.ts`
- make Blog, Careers and Partners pages pull data from the CMS
- add detail pages for blog posts, career postings and partners
- expose routes for these new pages in `App.tsx`
- provide `.env.example` for configuring `VITE_CMS_BASE_URL`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c0827aca48330b9adf7a354d6f302