### PR TITLE
Enable dynamic loading for translations and layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ const BlogPostPage = lazy(() => import("./pages/BlogPostPage"));
 const CareerPostPage = lazy(() => import("./pages/CareerPostPage"));
 const PartnerPage = lazy(() => import("./pages/PartnerPage"));
 const NotFound = lazy(() => import("./pages/NotFound"));
-import Layout from "./components/Layout";
+const Layout = lazy(() => import("./components/Layout"));
 
 
 const queryClient = new QueryClient();

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,6 +1,6 @@
 
-import { createContext, useContext, useState, ReactNode } from 'react';
-import { translations, type Language, type TranslationKey } from '@/locales';
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { loadTranslations, type Language, type TranslationKey } from '@/locales';
 
 interface LanguageContextType {
   language: Language;
@@ -14,6 +14,11 @@ const LanguageContext = createContext<LanguageContextType | undefined>(undefined
 export const LanguageProvider = ({ children }: { children: ReactNode }) => {
   // Default language Arabic with RTL direction
   const [language, setLanguageState] = useState<Language>('ar');
+  const [messages, setMessages] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    loadTranslations(language).then(setMessages);
+  }, [language]);
 
   const setLanguage = (lang: Language) => {
     setLanguageState(lang);
@@ -25,7 +30,7 @@ export const LanguageProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const t = (key: TranslationKey): string => {
-    return translations[language][key] || key;
+    return messages[key] || key;
   };
 
   const isRTL = language !== 'en';

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -1,15 +1,15 @@
+export type Language = 'en' | 'ar' | 'eg';
 
-import { en } from './en';
-import { ar } from './ar';
-import { eg } from './eg';
-
-export const translations = {
-  en,
-  ar,
-  eg,
-} as const;
+import type { en } from './en';
+import type { ar } from './ar';
+import type { eg } from './eg';
 
 export type TranslationKey = keyof typeof en;
-export type Language = keyof typeof translations;
 
-export { en, ar, eg };
+const loaders = {
+  en: () => import('./en').then(m => m.en),
+  ar: () => import('./ar').then(m => m.ar),
+  eg: () => import('./eg').then(m => m.eg),
+};
+
+export const loadTranslations = (lang: Language) => loaders[lang]();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,9 +45,12 @@ export default defineConfig(({ mode }) => {
       minify: "esbuild",
       rollupOptions: {
         output: {
-          manualChunks: {
-            vendor: ['react', 'react-dom'],
-            ui: ['@radix-ui/react-dialog', '@radix-ui/react-dropdown-menu']
+          manualChunks(id) {
+            if (id.includes('node_modules')) {
+              if (id.includes('react')) return 'vendor';
+              if (id.includes('@radix-ui')) return 'ui';
+            }
+            if (id.includes('src/locales')) return 'locales';
           }
         }
       }


### PR DESCRIPTION
## Summary
- lazy load `Layout` component
- lazy load locale files via `loadTranslations`
- handle translation loading in `LanguageContext`
- optimize Vite build with manual chunking

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c22a71d5083308f61bc2b87149e55