### PR TITLE
Standardize hero and nav text colors

### DIFF
--- a/docs/futuristic-color-schema.md
+++ b/docs/futuristic-color-schema.md
@@ -2,16 +2,18 @@
 
 This palette defines the primary design tokens used across the application. The values are declared as CSS variables in `src/index.css` and mapped in `tailwind.config.ts`.
 
-| Token              | HEX                   | Usage                    |
-| ------------------ | --------------------- | ------------------------ |
-| `primary`          | `#36f1fe`             | Main actions, buttons    |
-| `secondary`        | `#0fd8c1`             | Accents and info         |
-| `accent`           | `#9e5afc`             | Glows and highlights     |
-| `background-dark`  | `#101829`             | Default dark background  |
-| `background-light` | `#f5f8fc`             | Default light background |
-| `surface`          | `rgba(20,30,50,0.72)` | Glass panels             |
-| `text-dark`        | `#eaf6fa`             | Text in dark mode        |
-| `text-light`       | `#101829`             | Text in light mode       |
+| Token              | HEX                   | Usage                     |
+| ------------------ | --------------------- | ------------------------- |
+| `primary`          | `#36f1fe`             | Main actions, buttons     |
+| `secondary`        | `#0fd8c1`             | Accents and info          |
+| `accent`           | `#9e5afc`             | Glows and highlights      |
+| `moon`             | `#f7faff`             | Universal nav & hero text |
+| `active`           | `#2f62e9`             | Active underline color    |
+| `background-dark`  | `#101829`             | Default dark background   |
+| `background-light` | `#f5f8fc`             | Default light background  |
+| `surface`          | `rgba(20,30,50,0.72)` | Glass panels              |
+| `text-dark`        | `#f7faff`             | Text in dark mode         |
+| `text-light`       | `#101829`             | Text in light mode        |
 
 Example usage:
 

--- a/src/components/HeroSlider.tsx
+++ b/src/components/HeroSlider.tsx
@@ -1,79 +1,81 @@
-  import React, { useEffect, useState } from "react";
-  import { motion, AnimatePresence } from "framer-motion";
-  import { useLanguage } from "@/contexts/LanguageContext";
-    // Last 5 seconds
+import React, { useEffect, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useLanguage } from '@/contexts/LanguageContext';
+// Last 5 seconds
 
-  const SLIDES = [
-    {
-      image: "/hero-1.png",
-      text: {
-        en: "Limitless Innovation.",
-        ar: "ابتكار بلا حدود.",
-        eg: "الابتكار ملوش آخر."
-      },
-      subtitle: {
-        en: "Push beyond the possible.",
-        ar: "اكسر حدود الممكن.",
-        eg: "خلي الحلم حقيقة."
-      }
+const SLIDES = [
+  {
+    image: '/hero-1.png',
+    text: {
+      en: 'Limitless Innovation.',
+      ar: 'ابتكار بلا حدود.',
+      eg: 'الابتكار ملوش آخر.',
     },
-    {
-      image: "/hero-2.png",
-      text: {
-        en: "Empowering Tomorrow.",
-        ar: "تمكين الغد.",
-        eg: "مستقبلنا في إيدينا."
-      },
-      subtitle: {
-        en: "Crafting a brighter future.",
-        ar: "نبني مستقبلًا مشرقًا.",
-        eg: "نرسم مستقبل أفضل."
-      }
+    subtitle: {
+      en: 'Push beyond the possible.',
+      ar: 'اكسر حدود الممكن.',
+      eg: 'خلي الحلم حقيقة.',
     },
-    {
-      image: "/hero-3.png",
-      text: {
-        en: "Unleashing Potential.",
-        ar: "إطلاق العنان للإمكانات.",
-        eg: "إمكانياتنا بلا حدود."
-      },
-      subtitle: {
-        en: "Discover your true capabilities.",
-        ar: "اكتشف إمكانياتك الحقيقية.",
-        eg: "اكتشف قدراتك الحقيقية."
-      }
+  },
+  {
+    image: '/hero-2.png',
+    text: {
+      en: 'Empowering Tomorrow.',
+      ar: 'تمكين الغد.',
+      eg: 'مستقبلنا في إيدينا.',
     },
-    {
-      image: "/hero-4.png",
-      text: {
-        en: "Innovate. Inspire. Impact.",
-        ar: "ابتكر. ألهم. أثر.",
-        eg: "ابتكر. ألهم. اترك أثر."
-      },
-      subtitle: {
-        en: "Transforming ideas into reality.",
-        ar: "تحويل الأفكار إلى واقع.",
-        eg: "نحوّل الأفكار لواقع ملموس."
-      }
-    } 
+    subtitle: {
+      en: 'Crafting a brighter future.',
+      ar: 'نبني مستقبلًا مشرقًا.',
+      eg: 'نرسم مستقبل أفضل.',
+    },
+  },
+  {
+    image: '/hero-3.png',
+    text: {
+      en: 'Unleashing Potential.',
+      ar: 'إطلاق العنان للإمكانات.',
+      eg: 'إمكانياتنا بلا حدود.',
+    },
+    subtitle: {
+      en: 'Discover your true capabilities.',
+      ar: 'اكتشف إمكانياتك الحقيقية.',
+      eg: 'اكتشف قدراتك الحقيقية.',
+    },
+  },
+  {
+    image: '/hero-4.png',
+    text: {
+      en: 'Innovate. Inspire. Impact.',
+      ar: 'ابتكر. ألهم. أثر.',
+      eg: 'ابتكر. ألهم. اترك أثر.',
+    },
+    subtitle: {
+      en: 'Transforming ideas into reality.',
+      ar: 'تحويل الأفكار إلى واقع.',
+      eg: 'نحوّل الأفكار لواقع ملموس.',
+    },
+  },
+];
 
-  ];
-  
 const SLIDE_DURATION = 10000;
-const FADE_DURATION = 1.7;      // مدة التلاشي والتداخل (ثواني)
-const BLEND_DURATION = 1400;    // ms
+const FADE_DURATION = 1.7; // مدة التلاشي والتداخل (ثواني)
+const BLEND_DURATION = 1400; // ms
 
-export default function HeroSlider({ lang = "en" }) {
+export default function HeroSlider({ lang = 'en' }) {
   const [active, setActive] = useState(0);
   const [prev, setPrev] = useState<number | null>(null);
   const [showText, setShowText] = useState(false);
   const { language } = useLanguage();
-  const isRTL = language === "ar" || language === "eg";
+  const isRTL = language === 'ar' || language === 'eg';
 
   useEffect(() => {
     setShowText(false);
     const textIn = setTimeout(() => setShowText(true), SLIDE_DURATION / 2.6);
-    const textOut = setTimeout(() => setShowText(false), SLIDE_DURATION - BLEND_DURATION + 400);
+    const textOut = setTimeout(
+      () => setShowText(false),
+      SLIDE_DURATION - BLEND_DURATION + 400,
+    );
     const nextSlide = setTimeout(() => {
       setPrev(active);
       setActive((i) => (i + 1) % SLIDES.length);
@@ -90,57 +92,55 @@ export default function HeroSlider({ lang = "en" }) {
   // --- منطق الزوم للشرائح
   // الشرائح الفردية: زوم إن فقط
   // الشرائح الزوجية: زوم أوت فقط
-  function getScaleFor(activeIndex: number, phase: "init" | "anim" | "exit") {
+  function getScaleFor(activeIndex: number, phase: 'init' | 'anim' | 'exit') {
     if (activeIndex % 2 === 0) {
       // فردية: Zoom In
-      if (phase === "init") return 1.01;  // تبدأ شبه عادية
-      if (phase === "anim") return 1.16;  // تقترب ببطء (Zoom In)
-      if (phase === "exit") return 1.18;  // عند الخروج تكون وصلت زوم إن أقصى
+      if (phase === 'init') return 1.01; // تبدأ شبه عادية
+      if (phase === 'anim') return 1.16; // تقترب ببطء (Zoom In)
+      if (phase === 'exit') return 1.18; // عند الخروج تكون وصلت زوم إن أقصى
     } else {
       // زوجية: Zoom Out
-      if (phase === "init") return 1.19;  // تبدأ مكبرة
-      if (phase === "anim") return 1.05;  // تصغر ببطء (Zoom Out)
-      if (phase === "exit") return 1.03;  // عند الخروج تكون صغرت للحد المناسب
+      if (phase === 'init') return 1.19; // تبدأ مكبرة
+      if (phase === 'anim') return 1.05; // تصغر ببطء (Zoom Out)
+      if (phase === 'exit') return 1.03; // عند الخروج تكون صغرت للحد المناسب
     }
     return 1;
   }
 
   return (
     <div className="relative w-full h-[100vh] overflow-hidden bg-gradient-to-br from-[#030c2e] to-[#020816]">
-
       {/* صورة الشريحة السابقة (خروج تدريجي) */}
       <AnimatePresence>
         {prev !== null && (
           <motion.img
-            key={"prev" + prev}
+            key={'prev' + prev}
             src={SLIDES[prev].image}
             alt={SLIDES[prev].text[language]}
             className="absolute inset-0 w-full h-full object-cover"
             initial={{
               opacity: 1,
-              scale: getScaleFor(prev, "anim"),
-              filter: "blur(0px)",
-              y: 60
-
+              scale: getScaleFor(prev, 'anim'),
+              filter: 'blur(0px)',
+              y: 60,
             }}
             animate={{
               opacity: 0,
-              scale: getScaleFor(prev, "exit"),
-              filter: "blur(14px)",
-              y: 60
+              scale: getScaleFor(prev, 'exit'),
+              filter: 'blur(14px)',
+              y: 60,
             }}
             exit={{
-              y: 60
+              y: 60,
             }}
             transition={{
-              opacity: { duration: FADE_DURATION, ease: "easeInOut" },
-              scale: { duration: FADE_DURATION, ease: "linear" },
-              filter: { duration: FADE_DURATION * 0.9, ease: "easeInOut" }
+              opacity: { duration: FADE_DURATION, ease: 'easeInOut' },
+              scale: { duration: FADE_DURATION, ease: 'linear' },
+              filter: { duration: FADE_DURATION * 0.9, ease: 'easeInOut' },
             }}
             style={{
               minHeight: 500,
               zIndex: 2,
-              transform: isRTL ? "scaleX(-1)" : "none"
+              transform: isRTL ? 'scaleX(-1)' : 'none',
             }}
           />
         )}
@@ -149,35 +149,34 @@ export default function HeroSlider({ lang = "en" }) {
       {/* صورة الشريحة الحالية (دخول تدريجي مع زوم مناسب) */}
       <AnimatePresence mode="wait">
         <motion.img
-          key={"active" + active}
+          key={'active' + active}
           src={SLIDES[active].image}
           alt={SLIDES[active].text[language]}
           className="absolute inset-0 w-full h-full object-cover"
           initial={{
             opacity: 0,
-            scale: getScaleFor(active, "init"),
-            filter: "blur(18px)",
-            y: 60
+            scale: getScaleFor(active, 'init'),
+            filter: 'blur(18px)',
+            y: 60,
           }}
           animate={{
             opacity: 1,
-            scale: getScaleFor(active, "anim"),
-            filter: "blur(0px)",
-            y: 60
+            scale: getScaleFor(active, 'anim'),
+            filter: 'blur(0px)',
+            y: 60,
           }}
           exit={{
-            y:60
+            y: 60,
           }}
           transition={{
-            opacity: { duration: FADE_DURATION + 0.16, ease: "easeInOut" },
-            scale: { duration: SLIDE_DURATION / 1000, ease: "linear" },
-            filter: { duration: FADE_DURATION * 1.0, ease: "easeInOut" },
-    
+            opacity: { duration: FADE_DURATION + 0.16, ease: 'easeInOut' },
+            scale: { duration: SLIDE_DURATION / 1000, ease: 'linear' },
+            filter: { duration: FADE_DURATION * 1.0, ease: 'easeInOut' },
           }}
           style={{
             minHeight: 500,
             zIndex: 3,
-            transform: isRTL ? "scaleX(-1)" : "none"
+            transform: isRTL ? 'scaleX(-1)' : 'none',
           }}
         />
       </AnimatePresence>
@@ -189,44 +188,46 @@ export default function HeroSlider({ lang = "en" }) {
       <div
         className={`
           absolute inset-y-0
-          ${isRTL ? "right-0" : "left-0"}
+          ${isRTL ? 'right-0' : 'left-0'}
           w-1/2
           flex items-center
-          ${isRTL ? "justify-end pr-10" : "justify-start pl-10"}
+          ${isRTL ? 'justify-end pr-10' : 'justify-start pl-10'}
           z-20
           pointer-events-none
         `}
-        dir={isRTL ? "rtl" : "ltr"}
+        dir={isRTL ? 'rtl' : 'ltr'}
       >
         <AnimatePresence>
           {showText && (
             <motion.div
               key={active + language}
-              initial={{ opacity: 0, y: 40, filter: "blur(15px)" }}
-              animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
-              exit={{ opacity: 0, y: 30, filter: "blur(10px)" }}
+              initial={{ opacity: 0, y: 40, filter: 'blur(15px)' }}
+              animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
+              exit={{ opacity: 0, y: 30, filter: 'blur(10px)' }}
               transition={{
                 duration: 1.0,
                 staggerChildren: 0.22,
               }}
               className={`
                 flex flex-col max-w-xl w-full
-                ${isRTL ? "items-end text-right" : "items-start text-left"}
+                ${isRTL ? 'items-end text-right' : 'items-start text-left'}
               `}
             >
               <motion.h1
                 initial={{ opacity: 0, x: isRTL ? 120 : -120, scale: 0.94 }}
                 animate={{ opacity: 1, x: 0, scale: 1 }}
                 exit={{ opacity: 0, x: isRTL ? -35 : 35, scale: 1.08 }}
-                transition={{ duration: 1.1, type: "spring" }}
+                transition={{ duration: 1.1, type: 'spring' }}
                 className={`
-                  text-white/90 
-                  text-xl sm:text-3xl md:text-5xl 
-                  font-black 
-                  drop-shadow-[0_3px_20px_rgba(64,168,255,0.30)]
+                  text-xl sm:text-3xl md:text-5xl
+                  font-black
                   tracking-tight mb-2 animate-pulse
-                  ${isRTL ? "text-right" : "text-left"}
+                  ${isRTL ? 'text-right' : 'text-left'}
                 `}
+                style={{
+                  color: 'var(--color-moon)',
+                  textShadow: '0 0 10px var(--color-moon)',
+                }}
               >
                 {SLIDES[active].text[language]}
               </motion.h1>
@@ -234,15 +235,17 @@ export default function HeroSlider({ lang = "en" }) {
                 initial={{ opacity: 0, x: isRTL ? 96 : -96, scale: 0.94 }}
                 animate={{ opacity: 1, x: 0, scale: 1 }}
                 exit={{ opacity: 0, x: isRTL ? -28 : 28, scale: 1.07 }}
-                transition={{ duration: 1.1, type: "spring" }}
+                transition={{ duration: 1.1, type: 'spring' }}
                 className={`
-                  text-white/70
                   text-base sm:text-xl md:text-2xl
-                  font-medium 
+                  font-medium
                   tracking-wide
-                  drop-shadow
-                  ${isRTL ? "text-right" : "text-left"}
+                  ${isRTL ? 'text-right' : 'text-left'}
                 `}
+                style={{
+                  color: 'var(--color-moon)',
+                  filter: 'drop-shadow(0 0 6px var(--color-moon))',
+                }}
               >
                 {SLIDES[active].subtitle[language]}
               </motion.p>

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -1,22 +1,22 @@
-import React, { useEffect, useState, useCallback, useMemo } from "react";
-import { Menu, X, Sun, Moon, Globe } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { useLanguage } from "@/contexts/LanguageContext";
-import type { Language } from "@/contexts/LanguageContext";
-import { useTheme } from "@/contexts/ThemeContext";
-import { Logo } from "@/components/ui/logo";
-import { useScrollSpy } from "@/hooks/useScrollSpy";
-import { motion, AnimatePresence } from "framer-motion";
-import { cn } from "@/lib/utils";
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import { Menu, X, Sun, Moon, Globe } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useLanguage } from '@/contexts/LanguageContext';
+import type { Language } from '@/contexts/LanguageContext';
+import { useTheme } from '@/contexts/ThemeContext';
+import { Logo } from '@/components/ui/logo';
+import { useScrollSpy } from '@/hooks/useScrollSpy';
+import { motion, AnimatePresence } from 'framer-motion';
+import { cn } from '@/lib/utils';
 
 const NAVBAR_HEIGHT = 72;
 const SCROLL_THRESHOLD = 10; // اعتبر فوق 10px ليس Hero
 
 // Theme tokens
-const NAV_LIGHT = "var(--nav-text-light)";
-const NAV_LIGHT_ACTIVE = "var(--nav-active-light)";
-const NAV_DARK = "var(--nav-text-dark)";
-const NAV_DARK_ACTIVE = "var(--nav-active-dark)";
+const NAV_LIGHT = 'var(--nav-text-light)';
+const NAV_LIGHT_ACTIVE = 'var(--nav-active-light)';
+const NAV_DARK = 'var(--nav-text-dark)';
+const NAV_DARK_ACTIVE = 'var(--nav-active-dark)';
 
 export default function Navigation() {
   const [isOpen, setIsOpen] = useState(false);
@@ -32,52 +32,53 @@ export default function Navigation() {
   }, []);
 
   // عناصر التنقل
-  const navItems = useMemo(() => [
-    { key: "home" as const, href: "#hero", label: t("home") },
-    { key: "services" as const, href: "#services", label: t("services") },
-    { key: "about" as const, href: "#about", label: t("about") },
-    { key: "projects" as const, href: "#projects", label: t("projects") },
-    { key: "contact" as const, href: "#contact", label: t("contact") },
-  ], [t]);
+  const navItems = useMemo(
+    () => [
+      { key: 'home' as const, href: '#hero', label: t('home') },
+      { key: 'services' as const, href: '#services', label: t('services') },
+      { key: 'about' as const, href: '#about', label: t('about') },
+      { key: 'projects' as const, href: '#projects', label: t('projects') },
+      { key: 'contact' as const, href: '#contact', label: t('contact') },
+    ],
+    [t],
+  );
 
-  const activeId = useScrollSpy([
-    "hero", "services", "about", "projects", "contact"
-  ], NAVBAR_HEIGHT + 50);
+  const activeId = useScrollSpy(
+    ['hero', 'services', 'about', 'projects', 'contact'],
+    NAVBAR_HEIGHT + 50,
+  );
 
   // منطق تغيير اللغة
   const handleLanguageChange = useCallback(() => {
-    const order: Language[] = ["en", "ar", "eg"];
+    const order: Language[] = ['en', 'ar', 'eg'];
     const next = order[(order.indexOf(language) + 1) % order.length];
     setLanguage(next);
   }, [language, setLanguage]);
   const getLanguageLabel = useCallback(() => {
     switch (language) {
-      case "en": return "عربي";
-      case "ar": return "EN";
-      case "eg": return "English";
-      default: return "En";
+      case 'en':
+        return 'عربي';
+      case 'ar':
+        return 'EN';
+      case 'eg':
+        return 'English';
+      default:
+        return 'En';
     }
   }, [language]);
 
-  // دالة لتحديد لون النص (مشع في الأعلى/مناسب للأسفل)
-  const getNavTextColor = (isActive: boolean) => {
-    if (isHero) return isActive ? NAV_LIGHT_ACTIVE : NAV_LIGHT;
-    if (theme === "light") return ""; // tailwind default
-    return isActive ? NAV_DARK_ACTIVE : NAV_DARK;
-  };
+  const getNavTextColor = () => 'var(--color-moon)';
 
-  const getGlow = () => {
-    if (!isHero) return "none";
-    return theme === "light"
-      ? `drop-shadow(0 0 8px var(--nav-light-glow))`
-      : `drop-shadow(0 0 8px var(--nav-dark-glow))`;
-  };
+  const getGlow = (active?: boolean) =>
+    active
+      ? `drop-shadow(0 0 8px var(--color-moon))`
+      : `drop-shadow(0 0 4px var(--color-moon))`;
 
   // متغيرات قائمة الموبايل
   const mobileMenuVariants = {
     hidden: { opacity: 0, scale: 0.95 },
-    visible: { opacity: 1, scale: 1, transition: { duration: 0.3 }},
-    exit: { opacity: 0, scale: 0.95, transition: { duration: 0.2 }},
+    visible: { opacity: 1, scale: 1, transition: { duration: 0.3 } },
+    exit: { opacity: 0, scale: 0.95, transition: { duration: 0.2 } },
   };
 
   // تحكم في التنقل السلس
@@ -85,7 +86,10 @@ export default function Navigation() {
     const element = document.getElementById(sectionId);
     if (element) {
       const offset = sectionId === 'hero' ? 0 : NAVBAR_HEIGHT;
-      const top = sectionId === 'hero' ? 0 : element.getBoundingClientRect().top + window.scrollY - offset;
+      const top =
+        sectionId === 'hero'
+          ? 0
+          : element.getBoundingClientRect().top + window.scrollY - offset;
       window.scrollTo({ top, behavior: 'smooth' });
       setIsOpen(false);
     }
@@ -93,17 +97,17 @@ export default function Navigation() {
 
   return (
     <motion.nav
-      dir={isRTL ? "rtl" : "ltr"}
+      dir={isRTL ? 'rtl' : 'ltr'}
       className={cn(
-        "fixed top-0 w-full z-50 transition-all duration-500 ease-out",
+        'fixed top-0 w-full z-50 transition-all duration-500 ease-out',
         isHero
-          ? "bg-transparent"
-          : "bg-background dark:bg-midnight/95 backdrop-blur-xl shadow-lg border-b border-border/50"
+          ? 'bg-transparent'
+          : 'bg-background dark:bg-midnight/95 backdrop-blur-xl shadow-lg border-b border-border/50',
       )}
       style={{ height: `${NAVBAR_HEIGHT}px` }}
       initial={{ y: -100 }}
       animate={{ y: 0 }}
-      transition={{ duration: 0.6, ease: "easeOut" }}
+      transition={{ duration: 0.6, ease: 'easeOut' }}
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-full">
         <div className="flex items-center justify-between h-full">
@@ -126,15 +130,18 @@ export default function Navigation() {
                   whileHover={{ scale: 1.08 }}
                   whileTap={{ scale: 0.97 }}
                   style={{
-                    color: getNavTextColor(isActive),
-                    textShadow: isHero ? `0 0 9px var(--nav-shadow)` : "none",
+                    color: getNavTextColor(),
+                    textShadow: isHero ? `0 0 9px var(--nav-shadow)` : 'none',
                     fontWeight: isActive ? 700 : 500,
+                    filter: getGlow(isActive),
+                    borderColor: isActive
+                      ? 'var(--color-active)'
+                      : 'transparent',
                   }}
                   className={cn(
-                    "relative px-4 py-2 mx-1 text-sm lg:text-base font-medium rounded-lg",
-                    "transition-all duration-300 ease-out",
-                    isActive && "border-b-2 border-primary",
-                    !isHero && theme === "light" && !isActive && "text-foreground hover:text-primary"
+                    'relative px-4 py-2 mx-1 text-sm lg:text-base font-medium rounded-lg',
+                    'transition-all duration-300 ease-out',
+                    isActive && 'border-b-2',
                   )}
                 >
                   <span className="relative z-10">{item.label}</span>
@@ -150,16 +157,18 @@ export default function Navigation() {
                 variant="ghost"
                 size="icon"
                 onClick={toggleTheme}
-                aria-label={theme === "light" ? "Enable dark mode" : "Enable light mode"}
+                aria-label={
+                  theme === 'light' ? 'Enable dark mode' : 'Enable light mode'
+                }
                 style={{
-                  color: getNavTextColor(false),
+                  color: getNavTextColor(),
                   filter: getGlow(),
                 }}
                 className={cn(
-                  "rounded-full w-10 h-10 transition-colors duration-300"
+                  'rounded-full w-10 h-10 transition-colors duration-300',
                 )}
               >
-                {theme === "light" ? (
+                {theme === 'light' ? (
                   <Moon className="h-4 w-4" />
                 ) : (
                   <Sun className="h-4 w-4" />
@@ -173,12 +182,12 @@ export default function Navigation() {
                 size="sm"
                 onClick={handleLanguageChange}
                 style={{
-                  color: getNavTextColor(false),
+                  color: getNavTextColor(),
                   filter: getGlow(),
                   fontWeight: 600,
                 }}
                 className={cn(
-                  "rounded-full text-xs lg:text-sm font-medium transition-colors duration-300"
+                  'rounded-full text-xs lg:text-sm font-medium transition-colors duration-300',
                 )}
               >
                 <Globe className="h-3 w-3 lg:h-4 lg:w-4 mr-1 lg:mr-2" />
@@ -192,14 +201,16 @@ export default function Navigation() {
                   variant="ghost"
                   size="icon"
                   onClick={() => setIsOpen(!isOpen)}
-                  aria-label={isOpen ? "Close menu" : "Open menu"}
+                  aria-label={isOpen ? 'Close menu' : 'Open menu'}
                   aria-expanded={isOpen}
                   aria-controls="mobile-menu"
                   style={{
-                    color: getNavTextColor(false),
+                    color: getNavTextColor(),
                     filter: getGlow(),
                   }}
-                  className={cn("rounded-full w-10 h-10 transition-colors duration-300")}
+                  className={cn(
+                    'rounded-full w-10 h-10 transition-colors duration-300',
+                  )}
                 >
                   <AnimatePresence mode="wait">
                     <motion.div
@@ -209,7 +220,11 @@ export default function Navigation() {
                       exit={{ rotate: 90, opacity: 0 }}
                       transition={{ duration: 0.2 }}
                     >
-                      {isOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+                      {isOpen ? (
+                        <X className="h-5 w-5" />
+                      ) : (
+                        <Menu className="h-5 w-5" />
+                      )}
                     </motion.div>
                   </AnimatePresence>
                 </Button>
@@ -237,24 +252,32 @@ export default function Navigation() {
                       key={item.key}
                       onClick={() => scrollToSection(item.href.slice(1))}
                       initial={{ opacity: 0, y: 30 }}
-                      animate={{ 
-                        opacity: 1, 
+                      animate={{
+                        opacity: 1,
                         y: 0,
-                        transition: { delay: index * 0.09, duration: 0.29, ease: "easeOut" }
+                        transition: {
+                          delay: index * 0.09,
+                          duration: 0.29,
+                          ease: 'easeOut',
+                        },
                       }}
                       whileHover={{ scale: 1.1 }}
                       whileTap={{ scale: 0.95 }}
                       style={{
-                        color: getNavTextColor(isActive),
-                        textShadow: isHero ? `0 0 9px var(--nav-shadow-soft)` : "none",
+                        color: getNavTextColor(),
+                        textShadow: isHero
+                          ? `0 0 9px var(--nav-shadow-soft)`
+                          : 'none',
                         fontWeight: isActive ? 700 : 600,
+                        filter: getGlow(isActive),
+                        borderColor: isActive
+                          ? 'var(--color-active)'
+                          : 'transparent',
                       }}
                       className={cn(
-                        "relative text-2xl font-semibold transition-all duration-300",
-                        "px-8 py-4 rounded-xl",
-                        isActive 
-                          ? "text-primary bg-primary/10 border border-primary/20" 
-                          : "hover:text-primary hover:bg-primary/5"
+                        'relative text-2xl font-semibold transition-all duration-300',
+                        'px-8 py-4 rounded-xl',
+                        isActive ? 'border-b-2' : 'hover:opacity-90',
                       )}
                     >
                       {item.label}

--- a/src/components/sections/LunarHeroSection/LunarHeroSection.tsx
+++ b/src/components/sections/LunarHeroSection/LunarHeroSection.tsx
@@ -1,17 +1,17 @@
-import React from "react";
-import { useTheme } from "@/contexts/ThemeContext";
-import { useLanguage } from "@/contexts/LanguageContext";
-import { cn } from "@/lib/utils";
-import PenguinMascot from "@/components/ui/PenguinMascot";
+import React from 'react';
+import { useTheme } from '@/contexts/ThemeContext';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { cn } from '@/lib/utils';
+import PenguinMascot from '@/components/ui/PenguinMascot';
 
 const translations = {
   en: {
-    title: "Askar Software Solutions",
-    subtitle: "Crafting elegant solutions under the calm of the lunar night.",
+    title: 'Askar Software Solutions',
+    subtitle: 'Crafting elegant solutions under the calm of the lunar night.',
   },
   ar: {
-    title: "أسكار للبرمجيات",
-    subtitle: "نبتكر حلولاً برمجية مميزة تحت هدوء الليل القمري.",
+    title: 'أسكار للبرمجيات',
+    subtitle: 'نبتكر حلولاً برمجية مميزة تحت هدوء الليل القمري.',
   },
 } as const;
 
@@ -21,14 +21,14 @@ export interface LunarHeroSectionProps {
   title?: string;
   subtitle?: string;
   showMascot?: boolean;
-  alignText?: "left" | "center" | "right";
+  alignText?: 'left' | 'center' | 'right';
 }
 
 const LunarHeroSection: React.FC<LunarHeroSectionProps> = ({
   title,
   subtitle,
   showMascot = true,
-  alignText = "center",
+  alignText = 'center',
 }) => {
   const { theme } = useTheme();
   const { language } = useLanguage();
@@ -39,14 +39,12 @@ const LunarHeroSection: React.FC<LunarHeroSectionProps> = ({
     <section
       id="hero"
       className={cn(
-        "relative pt-20 pb-20 overflow-hidden transition-colors duration-500",
-        alignText === "center" && "text-center",
-        alignText === "left" && "text-left",
-        alignText === "right" && "text-right",
-        theme === "dark"
-          ? "bg-midnight text-moonWhite"
-          : "bg-brand-bg text-foreground",
+        'relative pt-20 pb-20 overflow-hidden transition-colors duration-500 bg-midnight',
+        alignText === 'center' && 'text-center',
+        alignText === 'left' && 'text-left',
+        alignText === 'right' && 'text-right',
       )}
+      style={{ color: 'var(--color-moon)' }}
     >
       <div
         className="absolute inset-0 -z-10 bg-gradient-to-br from-brand-primary via-transparent to-brand-secondary/20"
@@ -60,10 +58,13 @@ const LunarHeroSection: React.FC<LunarHeroSectionProps> = ({
         className="absolute bottom-0 right-0 w-96 h-96 rounded-full bg-brand-secondary/10 blur-2xl"
         aria-hidden="true"
       />
-      <h1 className="font-heading text-brand-glow mb-4 animate-fade-in-up delay-100">
+      <h1
+        className="font-heading mb-4 animate-fade-in-up delay-100"
+        style={{ textShadow: '0 0 8px var(--color-moon)' }}
+      >
         {title ?? content.title}
       </h1>
-      <p className="text-base text-muted-foreground mb-8 animate-fade-in-up delay-100 max-w-xl mx-auto">
+      <p className="text-base mb-8 animate-fade-in-up delay-100 max-w-xl mx-auto">
         {subtitle ?? content.subtitle}
       </p>
       {showMascot && (

--- a/src/index.css
+++ b/src/index.css
@@ -43,14 +43,16 @@
     --spring-glow: 184 98% 60% / 0.4; /* Neon glow */
 
     /* Navigation System */
-    --nav-text-light: #101829; /* Light mode nav text */
-    --nav-active-light: #36f1fe; /* Active link on hero */
-    --nav-light-glow: #36f1fe70; /* Glow for icons */
-    --nav-text-dark: #eaf6fa; /* Dark mode nav text */
-    --nav-active-dark: #36f1fe; /* Dark mode active link */
-    --nav-dark-glow: #36f1fe80; /* Dark mode glow */
-    --nav-shadow: #0fd8c170; /* Light text shadow */
-    --nav-shadow-soft: #0fd8c150; /* Softer shadow for mobile */
+    --color-moon: #f7faff;
+    --color-active: #2f62e9;
+    --nav-text-light: var(--color-moon);
+    --nav-active-light: var(--color-moon);
+    --nav-light-glow: #f7faffb0;
+    --nav-text-dark: var(--color-moon);
+    --nav-active-dark: var(--color-moon);
+    --nav-dark-glow: #f7faffb0;
+    --nav-shadow: #f7faff80; /* Light text shadow */
+    --nav-shadow-soft: #f7faff50; /* Softer shadow for mobile */
 
     /* Hero Background */
     --hero-gradient-from: #030c2e;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -60,7 +60,8 @@ export default {
         // Ask-ar brand palette
         primary: '#36f1fe',
         accent: '#9e5afc',
-        moonWhite: '#eaf6fa',
+        moon: '#f7faff',
+        active: '#2f62e9',
         surface: '#f5f8fc',
         card: '#ffffff',
         muted: '#141e32',


### PR DESCRIPTION
## Summary
- define `moon` and `active` colors in Tailwind config
- use CSS variables for navigation text color
- update hero slider, hero section and navigation components to use constant moon text
- document color tokens in color schema docs

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c310b77c08330abc841f503946839