### PR TITLE
Refactor LunarHeroSection

### DIFF
--- a/src/components/sections/LunarHeroSection/LunarHeroSection.tsx
+++ b/src/components/sections/LunarHeroSection/LunarHeroSection.tsx
@@ -1,50 +1,52 @@
 import React from 'react';
-import { useTheme } from '@/contexts/ThemeContext';
+import { motion } from 'framer-motion';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { cn } from '@/lib/utils';
 import PenguinMascot from '@/components/ui/PenguinMascot';
+import { Button } from '@/components/ui/button';
 
-const translations = {
-  en: {
-    title: 'Askar Software Solutions',
-    subtitle: 'Crafting elegant solutions under the calm of the lunar night.',
+const containerVariants = {
+  hidden: { opacity: 0, y: 40 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { staggerChildren: 0.15, duration: 0.8 },
   },
-  ar: {
-    title: 'أصنع وأبتكر تطبيقك',
-    subtitle: 'نبتكر حلولاً برمجية مميزة تحت هدوء الليل القمري.',
-  },
-} as const;
+};
 
-type Locale = keyof typeof translations;
+const itemVariants = {
+  hidden: { opacity: 0, y: 20 },
+  show: { opacity: 1, y: 0 },
+};
 
 export interface LunarHeroSectionProps {
   title?: string;
   subtitle?: string;
   showMascot?: boolean;
-  alignText?: 'left' | 'center' | 'right';
+  illustrationSrc?: string;
 }
 
 const LunarHeroSection: React.FC<LunarHeroSectionProps> = ({
   title,
   subtitle,
   showMascot = true,
-  alignText = 'center',
+  illustrationSrc = '/images/cover.webp',
 }) => {
-  const { theme } = useTheme();
-  const { language } = useLanguage();
-
-  const content = translations[language as Locale];
+  const { t, isRTL } = useLanguage();
 
   return (
-    <section
+    <motion.section
       id="hero"
+      dir={isRTL ? 'rtl' : 'ltr'}
+      initial="hidden"
+      whileInView="show"
+      viewport={{ once: true, amount: 0.6 }}
+      variants={containerVariants}
       className={cn(
-        'relative pt-20 pb-20 overflow-hidden transition-colors duration-500 bg-midnight',
-        alignText === 'center' && 'text-center',
-        alignText === 'left' && 'text-left',
-        alignText === 'right' && 'text-right',
+        'relative overflow-hidden py-section text-moon',
+        'bg-gradient-to-br from-hero-from to-hero-to',
+        'dark:from-[var(--hero-gradient-dark-from)] dark:to-[var(--hero-gradient-dark-to)]',
       )}
-      style={{ color: 'var(--color-moon)' }}
     >
       <div
         className="absolute inset-0 -z-10 bg-gradient-to-br from-brand-primary via-transparent to-brand-secondary/20"
@@ -58,16 +60,54 @@ const LunarHeroSection: React.FC<LunarHeroSectionProps> = ({
         className="absolute bottom-0 right-0 w-96 h-96 rounded-full bg-brand-secondary/10 blur-2xl"
         aria-hidden="true"
       />
-      <h1
-        className="font-heading mb-4 animate-fade-in-up delay-100"
-        style={{ textShadow: '0 0 8px var(--color-moon)' }}
-      >
-        {title ?? content.title}
-      </h1>
-      <p className="text-base mb-8 animate-fade-in-up delay-100 max-w-xl mx-auto">
-        {subtitle ?? content.subtitle}
-      </p>
-    </section>
+      <div className="container grid items-center gap-10 md:grid-cols-2">
+        <motion.div
+          variants={itemVariants}
+          className={cn(
+            'relative z-10 space-y-6 p-6 rounded-glass border border-glass-border bg-glass-bg/60 backdrop-blur-lg shadow-glow',
+            isRTL ? 'md:order-2 text-right' : 'text-left',
+          )}
+        >
+          <motion.h1
+            variants={itemVariants}
+            className="text-4xl md:text-5xl font-heading font-bold drop-shadow-[0_0_8px_var(--color-moon)]"
+          >
+            {title ?? t('heroTitle')}
+          </motion.h1>
+          <motion.p variants={itemVariants} className="text-lg max-w-xl">
+            {subtitle ?? t('heroSubtitle')}
+          </motion.p>
+          <motion.div
+            variants={itemVariants}
+            className={cn(
+              'flex gap-4',
+              isRTL ? 'justify-end' : 'justify-start',
+            )}
+          >
+            <Button variant="secondary" className="spring-button px-6 py-3">
+              {t('getStarted')}
+            </Button>
+            <Button variant="ghost" className="nav-link text-moon">
+              {t('learnMore')}
+            </Button>
+          </motion.div>
+        </motion.div>
+        <motion.div
+          variants={itemVariants}
+          className="relative z-10 flex justify-center"
+        >
+          {showMascot ? (
+            <PenguinMascot className="w-40 md:w-56 lg:w-64" />
+          ) : (
+            <img
+              src={illustrationSrc}
+              alt={t('heroTitle')}
+              className="max-w-md w-full object-cover rounded-2xl shadow-lunar-lg"
+            />
+          )}
+        </motion.div>
+      </div>
+    </motion.section>
   );
 };
 


### PR DESCRIPTION
## Summary
- overhaul `LunarHeroSection` with animations, responsive layout and tokens
- integrate translation hooks and add CTA buttons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688c3f504b2483309c64b2b3f75efce4