### PR TITLE
Improve navbar active state highlight

### DIFF
--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -71,7 +71,7 @@ export default function Navigation() {
 
   const getGlow = (active?: boolean) =>
     active
-      ? `drop-shadow(0 0 8px var(--color-moon))`
+      ? `drop-shadow(0 0 8px var(--color-active))`
       : `drop-shadow(0 0 4px var(--color-moon))`;
 
   // متغيرات قائمة الموبايل
@@ -130,7 +130,7 @@ export default function Navigation() {
                   whileHover={{ scale: 1.08 }}
                   whileTap={{ scale: 0.97 }}
                   style={{
-                    color: getNavTextColor(),
+                    color: isActive ? 'var(--color-active)' : getNavTextColor(),
                     textShadow: isHero ? `0 0 9px var(--nav-shadow)` : 'none',
                     fontWeight: isActive ? 700 : 500,
                     filter: getGlow(isActive),
@@ -264,7 +264,9 @@ export default function Navigation() {
                       whileHover={{ scale: 1.1 }}
                       whileTap={{ scale: 0.95 }}
                       style={{
-                        color: getNavTextColor(),
+                        color: isActive
+                          ? 'var(--color-active)'
+                          : getNavTextColor(),
                         textShadow: isHero
                           ? `0 0 9px var(--nav-shadow-soft)`
                           : 'none',


### PR DESCRIPTION
## Summary
- tweak navigation glow logic so active link glows with brand blue
- color active link text with the same blue shade in desktop and mobile menus

## Testing
- `npm test` *(no tests found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688c4b58c66c83308171548f8d4b9421